### PR TITLE
Overhaul site to neobrutalist design system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,15 +27,20 @@ The home page (`app/page.tsx`) is a single scroll of section components imported
 
 Hybrid approach: **MUI sx prop** for component-level styles, **Tailwind** for utility classes, **Emotion** under the hood for MUI. The `cn()` helper in `lib/utils.ts` merges clsx + tailwind-merge.
 
-Brand colors defined in `app/theme.ts`: surface `#FFFFFF`, ink `#111111`, accent `#E5C767` (champagne gold). MUI palette uses `#FCF5EC` (brown/cream) as primary and `#DD9F28` (gold) as secondary.
+**Design language: neobrutalism.** Flat saturated color, thick ink borders, hard offset shadows with zero blur, zero border radius, press-down button mechanics. No gradients, no glassmorphism, no soft glows, no pills, anywhere.
 
-Shared brand tokens live in `lib/theme.ts`:
-- `BRAND_ACCENT` (`#E5C767`) and `BRAND_ACCENT_DEEP` (`#C9A227`) — solid colors for icons, pill borders, active-nav underline, hover states, and any UI under ~20px where a gradient would read as muddy
-- `BRAND_GRADIENT` — `linear-gradient(135deg, #E5C767 → #E89B3C)`
-- `BRAND_GRADIENT_TEXT_SX` — spread into an sx object on big accent text (hero H1 spans, section H2 accent words, the huge case-study numbers)
-- `BRAND_GRADIENT_BUTTON_SX` — spread into an sx object on primary CTA buttons (uses `filter: brightness(0.92)` on hover)
+Core tokens live in `lib/theme.ts`:
+- Colors: `INK` (`#111111`), `PAPER` (`#F3EDE2` warm bone), `SURFACE` (`#FFFFFF` cards on light bg), `ACCENT` (`#C0C0C0` metallic silver), `POP` (`#FF5C00` safety orange, sparingly)
+- `NB_BORDER` (3px ink) / `NB_BORDER_THIN` (2px ink) — cards/buttons/inputs get structural borders (PAPER-colored on dark backgrounds)
+- `nbShadow(px, color?)` — hard offset shadow, e.g. `nbShadow(4)` small UI, `nbShadow(8)` cards; pass `ACCENT` or `PAPER` on dark backgrounds
+- `NB_CARD_SX` / `NB_CARD_DARK_SX` — card styles for light/dark sections
+- `NB_BUTTON_SX` — primary CTA: flat silver, ink border, hover `translate(-2px,-2px)` + shadow grows, active `translate(2px,2px)` + shadow 0
+- `NB_BUTTON_OUTLINE_DARK_SX`, `NB_TAG_DARK_SX` — secondary button and square badge on dark backgrounds
+- Legacy names (`BRAND_ACCENT`, `BRAND_GRADIENT`, `BRAND_GRADIENT_TEXT_SX`, `BRAND_GRADIENT_BUTTON_SX`) still export but resolve to flat styles; prefer the `NB_*` names in new code
 
-**Rule of thumb for the gradient**: apply only to hero-scale text and primary CTAs. Keep icons, tiny borders, navbar underline, and body-copy accents on the solid `BRAND_ACCENT` color.
+Fonts (via `next/font` in `app/layout.tsx`): Archivo Black (`--font-display`, headings, single 400 weight — never set bold on `h*` variants, it faux-bolds) and Space Grotesk (`--font-body`). MUI theme in `app/theme.ts` sets `shape.borderRadius: 0` and uppercase display headings; Tailwind exposes `ink/paper/silver/pop` colors and `shadow-brutal[-lg|-silver|-paper]`.
+
+House style rules: every section declares an explicit background (`INK` for hero/photo sections, `PAPER` for content-heavy surfaces); dark-light seams get a 4px `ACCENT` or `INK` rule; hero-scale accent statements can use one silver highlight block per page (`bgcolor: ACCENT, color: INK, hard shadow, rotate(-1.5deg)`); everything else uses flat `ACCENT` text.
 
 ### Routes
 

--- a/app/about-us/page.tsx
+++ b/app/about-us/page.tsx
@@ -3,6 +3,7 @@ import { Box } from "@mui/material";
 import AboutUs from "../components/AboutUs";
 import FoundersSection from "../components/FoundersSection";
 import Contact from "../components/Contact";
+import { ACCENT, INK } from "@/lib/theme";
 
 export const metadata: Metadata = {
   title: "About Us | DripDome - Women-Owned Set Design Studio NYC",
@@ -44,7 +45,7 @@ export default function AboutUsPage() {
     <Box>
       <AboutUs />
       <FoundersSection />
-      <Box sx={{ bgcolor: "black", py: 10 }}>
+      <Box sx={{ bgcolor: INK, borderTop: `4px solid ${ACCENT}`, py: 10 }}>
         <Contact />
       </Box>
     </Box>

--- a/app/blog/BlogContent.tsx
+++ b/app/blog/BlogContent.tsx
@@ -6,7 +6,15 @@ import Image from "next/image";
 import { Box, Typography, Chip } from "@mui/material";
 import { motion } from "framer-motion";
 import { blogPosts, getAllCategories } from "./data";
-import { BRAND_GRADIENT_TEXT_SX } from "@/lib/theme";
+import {
+  ACCENT,
+  INK,
+  NB_BORDER,
+  NB_BORDER_THIN,
+  PAPER,
+  SURFACE,
+  nbShadow,
+} from "@/lib/theme";
 
 export default function BlogContent() {
   const categories = getAllCategories();
@@ -16,8 +24,30 @@ export default function BlogContent() {
     ? blogPosts.filter((post) => post.category === activeCategory)
     : blogPosts;
 
+  const chipSx = (active: boolean) => ({
+    bgcolor: active ? ACCENT : SURFACE,
+    color: INK,
+    border: NB_BORDER_THIN,
+    borderRadius: 0,
+    boxShadow: active ? nbShadow(3) : "none",
+    fontWeight: 700,
+    fontSize: "14px",
+    textTransform: "uppercase" as const,
+    letterSpacing: "0.04em",
+    transition: "transform 120ms ease, box-shadow 120ms ease",
+    "&:hover": {
+      bgcolor: active ? ACCENT : SURFACE,
+      transform: "translate(-2px, -2px)",
+      boxShadow: nbShadow(active ? 5 : 3),
+    },
+    "&:active": {
+      transform: "translate(2px, 2px)",
+      boxShadow: nbShadow(0),
+    },
+  });
+
   return (
-    <Box sx={{ bgcolor: "black", overflow: "hidden", minHeight: "100vh" }}>
+    <Box sx={{ bgcolor: PAPER, overflow: "hidden", minHeight: "100vh" }}>
       {/* Hero Section */}
       <Box
         sx={{
@@ -37,8 +67,7 @@ export default function BlogContent() {
             variant="h1"
             sx={{
               fontSize: { xs: "42px", sm: "64px", md: "80px", lg: "96px" },
-              fontWeight: 800,
-              color: "white",
+              color: INK,
               textAlign: "center",
               mb: { xs: 3, md: 4 },
               letterSpacing: "-0.02em",
@@ -47,7 +76,14 @@ export default function BlogContent() {
             THE{" "}
             <Box
               component="span"
-              sx={{ display: "inline", ...BRAND_GRADIENT_TEXT_SX }}
+              sx={{
+                display: "inline-block",
+                bgcolor: ACCENT,
+                color: INK,
+                px: { xs: 1.5, md: 3 },
+                boxShadow: nbShadow(8),
+                transform: "rotate(-1.5deg)",
+              }}
             >
               BLOG
             </Box>
@@ -62,7 +98,7 @@ export default function BlogContent() {
           <Typography
             sx={{
               fontSize: { xs: "16px", sm: "18px", md: "22px" },
-              color: "rgba(255,255,255,0.85)",
+              color: INK,
               textAlign: "center",
               maxWidth: "900px",
               mx: "auto",
@@ -71,7 +107,7 @@ export default function BlogContent() {
           >
             Behind-the-scenes looks at our builds, fabrication deep dives, and
             insights from the{" "}
-            <Box component="span" sx={{ color: "#E5C767", fontWeight: 600 }}>
+            <Box component="span" sx={{ color: INK, fontWeight: 700 }}>
               DripDome
             </Box>{" "}
             studio.
@@ -99,47 +135,21 @@ export default function BlogContent() {
             sx={{
               display: "flex",
               flexWrap: "wrap",
-              gap: 1,
+              gap: 1.5,
               justifyContent: "center",
             }}
           >
             <Chip
               label="All"
               onClick={() => setActiveCategory(null)}
-              sx={{
-                bgcolor: !activeCategory
-                  ? "#E5C767"
-                  : "rgba(255,255,255,0.08)",
-                color: "white",
-                fontWeight: 600,
-                fontSize: "14px",
-                "&:hover": {
-                  bgcolor: !activeCategory
-                    ? "#E5C767"
-                    : "rgba(255,255,255,0.15)",
-                },
-              }}
+              sx={chipSx(!activeCategory)}
             />
             {categories.map((category) => (
               <Chip
                 key={category}
                 label={category}
                 onClick={() => setActiveCategory(category)}
-                sx={{
-                  bgcolor:
-                    activeCategory === category
-                      ? "#E5C767"
-                      : "rgba(255,255,255,0.08)",
-                  color: "white",
-                  fontWeight: 600,
-                  fontSize: "14px",
-                  "&:hover": {
-                    bgcolor:
-                      activeCategory === category
-                        ? "#E5C767"
-                        : "rgba(255,255,255,0.15)",
-                  },
-                }}
+                sx={chipSx(activeCategory === category)}
               />
             ))}
           </Box>
@@ -174,25 +184,29 @@ export default function BlogContent() {
               initial={{ opacity: 0, y: 30 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ delay: index * 0.1, duration: 0.5 }}
+              style={{ height: "100%" }}
             >
               <Link
                 href={`/blog/${post.slug}`}
-                style={{ textDecoration: "none" }}
+                style={{ textDecoration: "none", display: "block", height: "100%" }}
               >
                 <Box
                   sx={{
-                    borderRadius: 3,
-                    overflow: "hidden",
-                    bgcolor: "rgba(255,255,255,0.03)",
-                    border: "1px solid rgba(255,255,255,0.1)",
-                    transition: "all 0.3s ease",
+                    bgcolor: SURFACE,
+                    border: NB_BORDER,
+                    borderRadius: 0,
+                    boxShadow: nbShadow(6),
+                    transition: "transform 120ms ease, box-shadow 120ms ease",
                     height: "100%",
                     display: "flex",
                     flexDirection: "column",
                     "&:hover": {
-                      bgcolor: "rgba(255,255,255,0.06)",
-                      borderColor: "rgba(229,199,103,0.5)",
-                      transform: "translateY(-4px)",
+                      transform: "translate(-2px, -2px)",
+                      boxShadow: nbShadow(8),
+                    },
+                    "&:active": {
+                      transform: "translate(2px, 2px)",
+                      boxShadow: nbShadow(0),
                     },
                   }}
                 >
@@ -202,7 +216,8 @@ export default function BlogContent() {
                       position: "relative",
                       width: "100%",
                       height: 200,
-                      bgcolor: "rgba(255,255,255,0.05)",
+                      bgcolor: PAPER,
+                      borderBottom: NB_BORDER,
                     }}
                   >
                     <Image
@@ -236,7 +251,11 @@ export default function BlogContent() {
                         sx={{
                           fontSize: "12px",
                           fontWeight: 700,
-                          color: "#E5C767",
+                          bgcolor: ACCENT,
+                          color: INK,
+                          border: NB_BORDER_THIN,
+                          px: 1,
+                          py: 0.25,
                           letterSpacing: "0.1em",
                           textTransform: "uppercase",
                         }}
@@ -246,7 +265,7 @@ export default function BlogContent() {
                       <Typography
                         sx={{
                           fontSize: "12px",
-                          color: "rgba(255,255,255,0.5)",
+                          color: "rgba(17,17,17,0.6)",
                         }}
                       >
                         {post.readingTime}
@@ -259,7 +278,7 @@ export default function BlogContent() {
                       sx={{
                         fontSize: { xs: "18px", md: "20px" },
                         fontWeight: 700,
-                        color: "white",
+                        color: INK,
                         lineHeight: 1.3,
                         mb: 1.5,
                       }}
@@ -271,7 +290,7 @@ export default function BlogContent() {
                     <Typography
                       sx={{
                         fontSize: { xs: "14px", md: "15px" },
-                        color: "rgba(255,255,255,0.7)",
+                        color: "rgba(17,17,17,0.75)",
                         lineHeight: 1.6,
                         flex: 1,
                       }}
@@ -285,7 +304,7 @@ export default function BlogContent() {
                       dateTime={post.date}
                       sx={{
                         fontSize: "13px",
-                        color: "rgba(255,255,255,0.4)",
+                        color: "rgba(17,17,17,0.55)",
                         mt: 2,
                       }}
                     >

--- a/app/blog/[slug]/BlogPostContent.tsx
+++ b/app/blog/[slug]/BlogPostContent.tsx
@@ -10,6 +10,15 @@ import { Autoplay } from "swiper/modules";
 import "swiper/css";
 import ContactForm from "../../components/ContactForm";
 import { getPostBySlug } from "../data";
+import {
+  ACCENT,
+  INK,
+  NB_BORDER,
+  NB_BORDER_THIN,
+  PAPER,
+  SURFACE,
+  nbShadow,
+} from "@/lib/theme";
 
 export default function BlogPostContent({ slug }: { slug: string }) {
   const post = getPostBySlug(slug);
@@ -22,7 +31,7 @@ export default function BlogPostContent({ slug }: { slug: string }) {
   });
 
   return (
-    <Box sx={{ bgcolor: "black", overflow: "hidden", minHeight: "100vh" }}>
+    <Box sx={{ bgcolor: PAPER, overflow: "hidden", minHeight: "100vh" }}>
       <Box
         component="article"
         sx={{
@@ -56,7 +65,7 @@ export default function BlogPostContent({ slug }: { slug: string }) {
               <Link
                 href="/"
                 style={{
-                  color: "rgba(255,255,255,0.5)",
+                  color: "rgba(17,17,17,0.6)",
                   textDecoration: "none",
                   fontSize: "14px",
                 }}
@@ -66,7 +75,7 @@ export default function BlogPostContent({ slug }: { slug: string }) {
             </Box>
             <Typography
               component="li"
-              sx={{ color: "rgba(255,255,255,0.3)", fontSize: "14px" }}
+              sx={{ color: "rgba(17,17,17,0.35)", fontSize: "14px" }}
               aria-hidden="true"
             >
               /
@@ -75,7 +84,7 @@ export default function BlogPostContent({ slug }: { slug: string }) {
               <Link
                 href="/blog"
                 style={{
-                  color: "rgba(255,255,255,0.5)",
+                  color: "rgba(17,17,17,0.6)",
                   textDecoration: "none",
                   fontSize: "14px",
                 }}
@@ -85,7 +94,7 @@ export default function BlogPostContent({ slug }: { slug: string }) {
             </Box>
             <Typography
               component="li"
-              sx={{ color: "rgba(255,255,255,0.3)", fontSize: "14px" }}
+              sx={{ color: "rgba(17,17,17,0.35)", fontSize: "14px" }}
               aria-hidden="true"
             >
               /
@@ -93,7 +102,7 @@ export default function BlogPostContent({ slug }: { slug: string }) {
             <Typography
               component="li"
               sx={{
-                color: "rgba(255,255,255,0.7)",
+                color: "rgba(17,17,17,0.8)",
                 fontSize: "14px",
                 overflow: "hidden",
                 textOverflow: "ellipsis",
@@ -116,9 +125,15 @@ export default function BlogPostContent({ slug }: { slug: string }) {
             {/* Category */}
             <Typography
               sx={{
+                display: "inline-block",
                 fontSize: "13px",
                 fontWeight: 700,
-                color: "#E5C767",
+                bgcolor: ACCENT,
+                color: INK,
+                border: NB_BORDER_THIN,
+                boxShadow: nbShadow(3),
+                px: 1.5,
+                py: 0.5,
                 letterSpacing: "0.15em",
                 textTransform: "uppercase",
                 mb: 2,
@@ -132,8 +147,7 @@ export default function BlogPostContent({ slug }: { slug: string }) {
               variant="h1"
               sx={{
                 fontSize: { xs: "28px", sm: "36px", md: "44px" },
-                fontWeight: 800,
-                color: "white",
+                color: INK,
                 lineHeight: 1.2,
                 mb: 3,
                 letterSpacing: "-0.02em",
@@ -151,14 +165,14 @@ export default function BlogPostContent({ slug }: { slug: string }) {
                 gap: { xs: 1.5, md: 2 },
                 mb: { xs: 4, md: 5 },
                 pb: { xs: 3, md: 4 },
-                borderBottom: "1px solid rgba(255,255,255,0.1)",
+                borderBottom: NB_BORDER_THIN,
               }}
             >
               <Typography
                 sx={{
                   fontSize: "14px",
-                  color: "rgba(255,255,255,0.7)",
-                  fontWeight: 600,
+                  color: INK,
+                  fontWeight: 700,
                 }}
               >
                 {post.author.name}
@@ -166,7 +180,7 @@ export default function BlogPostContent({ slug }: { slug: string }) {
               {post.author.role && (
                 <>
                   <Typography
-                    sx={{ color: "rgba(255,255,255,0.3)", fontSize: "14px" }}
+                    sx={{ color: "rgba(17,17,17,0.35)", fontSize: "14px" }}
                     aria-hidden="true"
                   >
                     |
@@ -174,7 +188,7 @@ export default function BlogPostContent({ slug }: { slug: string }) {
                   <Typography
                     sx={{
                       fontSize: "14px",
-                      color: "rgba(255,255,255,0.5)",
+                      color: "rgba(17,17,17,0.6)",
                     }}
                   >
                     {post.author.role}
@@ -182,7 +196,7 @@ export default function BlogPostContent({ slug }: { slug: string }) {
                 </>
               )}
               <Typography
-                sx={{ color: "rgba(255,255,255,0.3)", fontSize: "14px" }}
+                sx={{ color: "rgba(17,17,17,0.35)", fontSize: "14px" }}
                 aria-hidden="true"
               >
                 |
@@ -192,13 +206,13 @@ export default function BlogPostContent({ slug }: { slug: string }) {
                 dateTime={post.date}
                 sx={{
                   fontSize: "14px",
-                  color: "rgba(255,255,255,0.5)",
+                  color: "rgba(17,17,17,0.6)",
                 }}
               >
                 {formattedDate}
               </Typography>
               <Typography
-                sx={{ color: "rgba(255,255,255,0.3)", fontSize: "14px" }}
+                sx={{ color: "rgba(17,17,17,0.35)", fontSize: "14px" }}
                 aria-hidden="true"
               >
                 |
@@ -206,7 +220,7 @@ export default function BlogPostContent({ slug }: { slug: string }) {
               <Typography
                 sx={{
                   fontSize: "14px",
-                  color: "rgba(255,255,255,0.5)",
+                  color: "rgba(17,17,17,0.6)",
                 }}
               >
                 {post.readingTime}
@@ -226,10 +240,11 @@ export default function BlogPostContent({ slug }: { slug: string }) {
               position: "relative",
               width: "100%",
               height: { xs: 220, sm: 300, md: 400 },
-              borderRadius: 3,
+              border: NB_BORDER,
+              boxShadow: nbShadow(8),
               overflow: "hidden",
               mb: { xs: 4, md: 5 },
-              bgcolor: "rgba(255,255,255,0.05)",
+              bgcolor: SURFACE,
             }}
           >
             <Image
@@ -253,7 +268,6 @@ export default function BlogPostContent({ slug }: { slug: string }) {
             <Box
               sx={{
                 mb: { xs: 4, md: 5 },
-                borderRadius: 3,
                 overflow: "hidden",
               }}
             >
@@ -275,9 +289,9 @@ export default function BlogPostContent({ slug }: { slug: string }) {
                         position: "relative",
                         width: "100%",
                         height: { xs: 220, sm: 280, md: 340 },
-                        borderRadius: 3,
+                        border: NB_BORDER,
                         overflow: "hidden",
-                        bgcolor: "rgba(255,255,255,0.05)",
+                        bgcolor: SURFACE,
                       }}
                     >
                       <Image
@@ -305,22 +319,26 @@ export default function BlogPostContent({ slug }: { slug: string }) {
             sx={{
               "& p": {
                 fontSize: { xs: "16px", md: "18px" },
-                color: "rgba(255,255,255,0.85)",
+                color: "rgba(17,17,17,0.85)",
                 lineHeight: 1.8,
                 mb: 3,
               },
               "& h2": {
+                fontFamily: "var(--font-display)",
+                fontWeight: 400,
+                textTransform: "uppercase",
                 fontSize: { xs: "22px", sm: "26px", md: "30px" },
-                fontWeight: 700,
-                color: "white",
+                color: INK,
                 mt: { xs: 5, md: 6 },
                 mb: { xs: 2, md: 3 },
                 lineHeight: 1.3,
               },
               "& h3": {
+                fontFamily: "var(--font-display)",
+                fontWeight: 400,
+                textTransform: "uppercase",
                 fontSize: { xs: "18px", sm: "20px", md: "24px" },
-                fontWeight: 700,
-                color: "white",
+                color: INK,
                 mt: { xs: 4, md: 5 },
                 mb: { xs: 1.5, md: 2 },
                 lineHeight: 1.3,
@@ -332,21 +350,24 @@ export default function BlogPostContent({ slug }: { slug: string }) {
               "& figure img": {
                 width: "100%",
                 height: "auto",
-                borderRadius: 3,
+                border: NB_BORDER,
+                boxShadow: nbShadow(6),
                 display: "block",
               },
               "& figcaption": {
                 textAlign: "center",
-                color: "rgba(255,255,255,0.5)",
+                color: "rgba(17,17,17,0.6)",
                 fontSize: "14px",
-                mt: 1,
+                mt: 2,
               },
               "& a": {
-                color: "#E5C767",
+                color: INK,
+                fontWeight: 700,
                 textDecoration: "underline",
+                textDecorationThickness: "2px",
                 textUnderlineOffset: "3px",
                 "&:hover": {
-                  opacity: 0.8,
+                  bgcolor: ACCENT,
                 },
               },
               "& ul, & ol": {
@@ -354,10 +375,10 @@ export default function BlogPostContent({ slug }: { slug: string }) {
                 mb: 3,
                 "& li": {
                   fontSize: { xs: "16px", md: "18px" },
-                  color: "rgba(255,255,255,0.85)",
+                  color: "rgba(17,17,17,0.85)",
                   lineHeight: 1.8,
                   mb: 1,
-                  "&::marker": { color: "#E5C767" },
+                  "&::marker": { color: INK, fontWeight: 700 },
                 },
               },
             }}
@@ -375,10 +396,10 @@ export default function BlogPostContent({ slug }: { slug: string }) {
             sx={{
               display: "flex",
               flexWrap: "wrap",
-              gap: 1,
+              gap: 1.5,
               mt: { xs: 4, md: 5 },
               pt: { xs: 3, md: 4 },
-              borderTop: "1px solid rgba(255,255,255,0.1)",
+              borderTop: NB_BORDER_THIN,
             }}
           >
             {post.tags.map((tag) => (
@@ -387,11 +408,12 @@ export default function BlogPostContent({ slug }: { slug: string }) {
                 sx={{
                   px: 2,
                   py: 0.5,
-                  borderRadius: 2,
-                  bgcolor: "rgba(255,255,255,0.06)",
-                  border: "1px solid rgba(255,255,255,0.1)",
+                  bgcolor: SURFACE,
+                  border: NB_BORDER_THIN,
+                  boxShadow: nbShadow(3),
                   fontSize: "13px",
-                  color: "rgba(255,255,255,0.6)",
+                  fontWeight: 700,
+                  color: INK,
                 }}
               >
                 {tag}
@@ -416,15 +438,15 @@ export default function BlogPostContent({ slug }: { slug: string }) {
                 gap: "8px",
               }}
             >
-              <ArrowBackIcon
-                sx={{ fontSize: 18, color: "#E5C767" }}
-              />
+              <ArrowBackIcon sx={{ fontSize: 18, color: INK }} />
               <Typography
                 sx={{
                   fontSize: "15px",
-                  fontWeight: 600,
-                  color: "#E5C767",
-                  "&:hover": { textDecoration: "underline" },
+                  fontWeight: 700,
+                  color: INK,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.04em",
+                  "&:hover": { bgcolor: ACCENT },
                 }}
               >
                 Back to all posts
@@ -432,52 +454,52 @@ export default function BlogPostContent({ slug }: { slug: string }) {
             </Link>
           </Box>
         </motion.div>
+      </Box>
 
-        {/* Contact CTA */}
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.6, duration: 0.6 }}
+      {/* Contact CTA — dark section with accent seam */}
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.6, duration: 0.6 }}
+      >
+        <Box
+          sx={{
+            bgcolor: INK,
+            borderTop: `4px solid ${ACCENT}`,
+            px: { xs: 2, md: 4 },
+            py: { xs: 6, md: 8 },
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+          }}
         >
-          <Box
+          <Typography
+            variant="h2"
+            component="h2"
             sx={{
-              mt: { xs: 6, md: 8 },
-              pt: { xs: 5, md: 6 },
-              borderTop: "1px solid rgba(255,255,255,0.1)",
-              display: "flex",
-              flexDirection: "column",
-              alignItems: "center",
+              fontSize: { xs: "28px", sm: "36px", md: "44px" },
+              color: PAPER,
+              textAlign: "center",
+              mb: 1.5,
             }}
           >
-            <Typography
-              variant="h2"
-              component="h2"
-              sx={{
-                fontSize: { xs: "28px", sm: "36px", md: "44px" },
-                fontWeight: 800,
-                color: "white",
-                textAlign: "center",
-                mb: 1.5,
-              }}
-            >
-              Need Our Services?
-            </Typography>
-            <Typography
-              sx={{
-                fontSize: { xs: "16px", md: "18px" },
-                color: "rgba(255,255,255,0.6)",
-                textAlign: "center",
-                mb: { xs: 3, md: 4 },
-                maxWidth: 500,
-              }}
-            >
-              Tell us about your project and let&apos;s build something
-              together.
-            </Typography>
-            <ContactForm />
-          </Box>
-        </motion.div>
-      </Box>
+            Need Our Services?
+          </Typography>
+          <Typography
+            sx={{
+              fontSize: { xs: "16px", md: "18px" },
+              color: "rgba(243,237,226,0.75)",
+              textAlign: "center",
+              mb: { xs: 3, md: 4 },
+              maxWidth: 500,
+            }}
+          >
+            Tell us about your project and let&apos;s build something
+            together.
+          </Typography>
+          <ContactForm />
+        </Box>
+      </motion.div>
     </Box>
   );
 }

--- a/app/blog/data.ts
+++ b/app/blog/data.ts
@@ -167,13 +167,13 @@ export const blogPosts: BlogPost[] = [
 <p>Before anything was built, DripDome created a full 3D render of the installation to iterate on the concept with the client. This let both teams align on scale, prop placement, and how the set would interact with the venue's existing greenery before a single material was sourced.</p>
 
 <figure style="margin: 2rem 0;">
-<img src="https://dripdome-site.s3.us-east-2.amazonaws.com/lesgc/render.jpg" alt="3D render of DripDome's Alice in Wonderland hedge wall set design for the Lower East Side Girls Club gala" style="width: 100%; border-radius: 12px;" />
-<figcaption style="text-align: center; color: rgba(255,255,255,0.5); font-size: 14px; margin-top: 8px;">The 3D render used during pre-production to finalize the concept with the client.</figcaption>
+<img src="https://dripdome-site.s3.us-east-2.amazonaws.com/lesgc/render.jpg" alt="3D render of DripDome's Alice in Wonderland hedge wall set design for the Lower East Side Girls Club gala" style="width: 100%; border-radius: 0; border: 3px solid #111111; box-shadow: 6px 6px 0 0 #111111;" />
+<figcaption style="text-align: center; color: rgba(17,17,17,0.6); font-size: 14px; margin-top: 14px;">The 3D render used during pre-production to finalize the concept with the client.</figcaption>
 </figure>
 
 <figure style="margin: 2rem 0;">
-<img src="https://dripdome-site.s3.us-east-2.amazonaws.com/lesgc/view.jpg" alt="The finished Alice in Wonderland hedge wall set at the Lower East Side Girls Club gala, a near 1:1 match of the 3D render" style="width: 100%; border-radius: 12px;" />
-<figcaption style="text-align: center; color: rgba(255,255,255,0.5); font-size: 14px; margin-top: 8px;">The finished set on the night of the event. Nearly a 1:1 match from render to reality.</figcaption>
+<img src="https://dripdome-site.s3.us-east-2.amazonaws.com/lesgc/view.jpg" alt="The finished Alice in Wonderland hedge wall set at the Lower East Side Girls Club gala, a near 1:1 match of the 3D render" style="width: 100%; border-radius: 0; border: 3px solid #111111; box-shadow: 6px 6px 0 0 #111111;" />
+<figcaption style="text-align: center; color: rgba(17,17,17,0.6); font-size: 14px; margin-top: 14px;">The finished set on the night of the event. Nearly a 1:1 match from render to reality.</figcaption>
 </figure>
 
 <p>The result was a set that felt like it grew out of the room rather than being dropped into it. The hedge wall flat served as the foundation, covered in faux hedging that blended seamlessly with the venue's natural greenery. Oversized flowers and hanging frames pushed the scene into Wonderland territory without losing the elegance a gala demands.</p>
@@ -204,7 +204,7 @@ export const blogPosts: BlogPost[] = [
 
 <h2>What's Next</h2>
 
-<p>DripDome's Wonderland work didn't start or end with LESGC. The team also designed sets for pop artist Emei's Into the Rabbit Hole EP, creating the environments for the full series of <a href="http://youtube.com/playlist?list=PLhBeWmAWC98WAZJ2tgc7hTVRT2T50ZL_2" target="_blank" rel="noopener noreferrer" style="color: #E5C767;">visualizers on YouTube</a>. Another project where the Alice in Wonderland thread drove the creative direction. When a concept keeps finding new contexts, it's not a coincidence. It's a creative language worth building on.</p>`,
+<p>DripDome's Wonderland work didn't start or end with LESGC. The team also designed sets for pop artist Emei's Into the Rabbit Hole EP, creating the environments for the full series of <a href="http://youtube.com/playlist?list=PLhBeWmAWC98WAZJ2tgc7hTVRT2T50ZL_2" target="_blank" rel="noopener noreferrer">visualizers on YouTube</a>. Another project where the Alice in Wonderland thread drove the creative direction. When a concept keeps finding new contexts, it's not a coincidence. It's a creative language worth building on.</p>`,
     date: "2026-04-11",
     author: {
       name: "DripDome Team",

--- a/app/brand-activations/BrandActivationForm.tsx
+++ b/app/brand-activations/BrandActivationForm.tsx
@@ -14,7 +14,7 @@ import {
 } from "@mui/material";
 import ReCAPTCHA from "react-google-recaptcha";
 import { trackGenerateLead } from "@/lib/analytics";
-import { BRAND_GRADIENT_BUTTON_SX } from "@/lib/theme";
+import { INK, NB_BUTTON_SX, PAPER, nbShadow } from "@/lib/theme";
 
 const BUDGET_RANGES = [
   "$10K – $25K",
@@ -24,14 +24,25 @@ const BUDGET_RANGES = [
 ];
 
 const inputStyles = {
-  "& .MuiInputBase-root": { bgcolor: "white", color: "black" },
+  "& .MuiInputBase-root": {
+    bgcolor: "white",
+    color: INK,
+    borderRadius: 0,
+    boxShadow: nbShadow(4),
+  },
   "& .MuiInputBase-input::placeholder": {
-    color: "rgba(0,0,0,0.7)",
+    color: "rgba(17,17,17,0.7)",
     opacity: 1,
   },
-  "& .MuiInputLabel-root": { color: "rgba(0,0,0,0.7)" },
+  "& .MuiInputLabel-root": { color: "rgba(17,17,17,0.7)" },
   "& .MuiOutlinedInput-notchedOutline": {
-    borderColor: "rgba(0,0,0,0.23)",
+    border: `3px solid ${INK}`,
+  },
+  "& .MuiInputBase-root:hover .MuiOutlinedInput-notchedOutline": {
+    border: `3px solid ${INK}`,
+  },
+  "& .MuiInputBase-root.Mui-focused .MuiOutlinedInput-notchedOutline": {
+    border: `3px solid ${INK}`,
   },
 };
 
@@ -53,8 +64,8 @@ export default function BrandActivationForm() {
         alignItems: "center",
         px: { xs: 3, md: 8 },
         py: { xs: 6, md: 10 },
-        bgcolor: "black",
-        color: "white",
+        bgcolor: PAPER,
+        color: INK,
       }}
     >
       <Typography
@@ -62,10 +73,9 @@ export default function BrandActivationForm() {
         component="h2"
         sx={{
           fontSize: { xs: "36px", md: "56px", lg: "64px" },
-          fontWeight: "bold",
           mb: 1,
           textAlign: "center",
-          color: "white",
+          color: INK,
         }}
       >
         REQUEST A PROJECT QUOTE
@@ -76,7 +86,7 @@ export default function BrandActivationForm() {
           textAlign: "center",
           maxWidth: 720,
           mb: 4,
-          color: "rgba(255,255,255,0.85)",
+          color: "rgba(17,17,17,0.8)",
         }}
       >
         Tell us about your brief. We reply within 48 hours with next steps.
@@ -184,7 +194,7 @@ export default function BrandActivationForm() {
               fontSize: "12px",
               fontWeight: 700,
               letterSpacing: "0.1em",
-              color: "rgba(255,255,255,0.7)",
+              color: "rgba(17,17,17,0.7)",
               mb: 0.75,
             }}
           >
@@ -203,10 +213,9 @@ export default function BrandActivationForm() {
         <FormControl
           fullWidth
           sx={{
-            "& .MuiInputBase-root": { bgcolor: "white", color: "black" },
-            "& .MuiInputLabel-root": { color: "rgba(0,0,0,0.7)" },
-            "& .MuiInputLabel-root.Mui-focused": { color: "black" },
-            "& .MuiSelect-select": { color: "black" },
+            ...inputStyles,
+            "& .MuiInputLabel-root.Mui-focused": { color: INK },
+            "& .MuiSelect-select": { color: INK },
           }}
         >
           <InputLabel id="budget-label">BUDGET RANGE</InputLabel>
@@ -260,13 +269,14 @@ export default function BrandActivationForm() {
             py: 1.75,
             width: "100%",
             maxWidth: 780,
-            fontWeight: 700,
             fontSize: "16px",
             letterSpacing: "0.05em",
-            ...BRAND_GRADIENT_BUTTON_SX,
+            ...NB_BUTTON_SX,
             "&.Mui-disabled": {
-              background: "rgba(229,199,103,0.4)",
-              color: "white",
+              bgcolor: "white",
+              color: "rgba(17,17,17,0.5)",
+              border: `3px solid ${INK}`,
+              boxShadow: "none",
             },
           }}
         >

--- a/app/brand-activations/BrandActivationsFAQ.tsx
+++ b/app/brand-activations/BrandActivationsFAQ.tsx
@@ -8,7 +8,7 @@ import {
   Typography,
 } from "@mui/material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import { BRAND_GRADIENT_TEXT_SX } from "@/lib/theme";
+import { ACCENT, INK, NB_BORDER, PAPER, SURFACE, nbShadow } from "@/lib/theme";
 
 // TODO: refine copy with founder-voice answers. Draft answers below are
 // placeholders that reflect the Ads plan's positioning (2 week turnaround,
@@ -36,8 +36,9 @@ export default function BrandActivationsFAQ() {
   return (
     <Box
       sx={{
-        bgcolor: "black",
-        color: "white",
+        bgcolor: PAPER,
+        color: INK,
+        borderTop: `4px solid ${ACCENT}`,
         px: { xs: 3, md: 8 },
         py: { xs: 8, md: 12 },
       }}
@@ -48,35 +49,37 @@ export default function BrandActivationsFAQ() {
           component="h2"
           sx={{
             fontSize: { xs: "32px", md: "50px", lg: "60px" },
-            fontWeight: "bold",
             textAlign: "center",
             mb: { xs: 4, md: 6 },
           }}
         >
-          <Box component="span" sx={{ color: "white" }}>
+          <Box component="span" sx={{ color: INK }}>
             COMMONLY{" "}
           </Box>
-          <Box component="span" sx={BRAND_GRADIENT_TEXT_SX}>
+          <Box component="span" sx={{ color: ACCENT }}>
             ASKED
           </Box>
         </Typography>
 
-        <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
           {FAQS.map((item, i) => (
             <Accordion
               key={i}
               disableGutters
+              square
+              elevation={0}
               sx={{
-                bgcolor: "rgba(255,255,255,0.04)",
-                color: "white",
-                border: "1px solid rgba(229,199,103,0.2)",
-                borderRadius: "12px !important",
+                bgcolor: SURFACE,
+                color: INK,
+                border: NB_BORDER,
+                borderRadius: "0 !important",
+                boxShadow: nbShadow(6),
                 "&:before": { display: "none" },
                 overflow: "hidden",
               }}
             >
               <AccordionSummary
-                expandIcon={<ExpandMoreIcon sx={{ color: "#E5C767" }} />}
+                expandIcon={<ExpandMoreIcon sx={{ color: INK }} />}
                 sx={{
                   px: { xs: 2, md: 3 },
                   py: 1,
@@ -86,7 +89,7 @@ export default function BrandActivationsFAQ() {
                 <Typography
                   sx={{
                     fontSize: { xs: "16px", md: "18px" },
-                    fontWeight: 600,
+                    fontWeight: 700,
                   }}
                 >
                   {item.q}
@@ -96,7 +99,7 @@ export default function BrandActivationsFAQ() {
                 <Typography
                   sx={{
                     fontSize: { xs: "15px", md: "16px" },
-                    color: "rgba(255,255,255,0.85)",
+                    color: "rgba(17,17,17,0.8)",
                     lineHeight: 1.6,
                   }}
                 >

--- a/app/brand-activations/BrandActivationsHero.tsx
+++ b/app/brand-activations/BrandActivationsHero.tsx
@@ -3,7 +3,14 @@
 import { Box, Button, Typography } from "@mui/material";
 import Image from "next/image";
 import { motion } from "framer-motion";
-import { BRAND_GRADIENT_BUTTON_SX, BRAND_GRADIENT_TEXT_SX } from "@/lib/theme";
+import {
+  ACCENT,
+  INK,
+  NB_BUTTON_OUTLINE_DARK_SX,
+  NB_BUTTON_SX,
+  NB_TAG_DARK_SX,
+  nbShadow,
+} from "@/lib/theme";
 
 // TODO: replace hero image with a 15s branded reel once produced
 // (use <video autoPlay muted loop playsInline> with a webm/mp4 hosted on S3).
@@ -23,7 +30,8 @@ export default function BrandActivationsHero() {
         display: "flex",
         alignItems: "center",
         justifyContent: "center",
-        bgcolor: "black",
+        bgcolor: INK,
+        borderBottom: `4px solid ${ACCENT}`,
         pt: { xs: "95px", md: "40px" },
       }}
     >
@@ -39,8 +47,7 @@ export default function BrandActivationsHero() {
         sx={{
           position: "absolute",
           inset: 0,
-          background:
-            "linear-gradient(180deg, rgba(0,0,0,0.35) 0%, rgba(0,0,0,0.85) 100%)",
+          bgcolor: "rgba(17,17,17,0.55)",
         }}
       />
 
@@ -73,15 +80,8 @@ export default function BrandActivationsHero() {
               <Box
                 key={badge}
                 sx={{
-                  px: 2,
-                  py: 0.75,
-                  border: "1px solid rgba(229,199,103,0.6)",
-                  borderRadius: "999px",
+                  ...NB_TAG_DARK_SX,
                   fontSize: { xs: "11px", md: "13px" },
-                  fontWeight: 600,
-                  letterSpacing: "0.1em",
-                  color: "white",
-                  bgcolor: "rgba(229,199,103,0.08)",
                 }}
               >
                 {badge}
@@ -106,15 +106,26 @@ export default function BrandActivationsHero() {
                 lg: "72px",
                 xl: "96px",
               },
-              fontWeight: "bold",
-              lineHeight: 1.05,
+              lineHeight: 1.1,
               color: "white",
               mb: { xs: 3, lg: 2.5, xl: 3 },
             }}
           >
             NYC BRAND ACTIVATION STUDIO.
             <br />
-            <Box component="span" sx={BRAND_GRADIENT_TEXT_SX}>
+            <Box
+              component="span"
+              sx={{
+                display: "inline-block",
+                bgcolor: ACCENT,
+                color: INK,
+                px: { xs: 1.5, md: 3 },
+                py: { xs: 0.5, md: 1 },
+                mt: { xs: 1.5, md: 2 },
+                boxShadow: nbShadow(8),
+                transform: "rotate(-1.5deg)",
+              }}
+            >
               DESIGNED. BUILT. INSTALLED.
             </Box>
           </Typography>
@@ -156,13 +167,13 @@ export default function BrandActivationsHero() {
               component="a"
               href="#inquiry"
               variant="contained"
+              disableElevation
               sx={{
                 px: 4,
                 py: 1.75,
                 fontSize: { xs: "14px", md: "16px" },
-                fontWeight: 700,
                 letterSpacing: "0.08em",
-                ...BRAND_GRADIENT_BUTTON_SX,
+                ...NB_BUTTON_SX,
               }}
             >
               REQUEST A QUOTE
@@ -181,14 +192,8 @@ export default function BrandActivationsHero() {
                 px: 4,
                 py: 1.75,
                 fontSize: { xs: "14px", md: "16px" },
-                fontWeight: 700,
                 letterSpacing: "0.08em",
-                color: "white",
-                borderColor: "rgba(255,255,255,0.6)",
-                "&:hover": {
-                  borderColor: "white",
-                  bgcolor: "rgba(255,255,255,0.08)",
-                },
+                ...NB_BUTTON_OUTLINE_DARK_SX,
               }}
             >
               SEE THE WORK

--- a/app/brand-activations/BrandActivationsProcess.tsx
+++ b/app/brand-activations/BrandActivationsProcess.tsx
@@ -5,7 +5,7 @@ import BrushIcon from "@mui/icons-material/Brush";
 import BuildIcon from "@mui/icons-material/Build";
 import LocalShippingIcon from "@mui/icons-material/LocalShipping";
 import { motion } from "framer-motion";
-import { BRAND_GRADIENT_TEXT_SX } from "@/lib/theme";
+import { ACCENT, INK, NB_BORDER, NB_CARD_SX, PAPER, nbShadow } from "@/lib/theme";
 
 const STEPS = [
   {
@@ -29,8 +29,9 @@ export default function BrandActivationsProcess() {
   return (
     <Box
       sx={{
-        bgcolor: "black",
-        color: "white",
+        bgcolor: PAPER,
+        color: INK,
+        borderBottom: `4px solid ${ACCENT}`,
         px: { xs: 3, md: 8 },
         py: { xs: 8, md: 12 },
       }}
@@ -41,21 +42,20 @@ export default function BrandActivationsProcess() {
           component="h2"
           sx={{
             fontSize: { xs: "32px", md: "50px", lg: "60px" },
-            fontWeight: "bold",
             mb: 2,
           }}
         >
-          <Box component="span" sx={{ color: "white" }}>
+          <Box component="span" sx={{ color: INK }}>
             EVERYTHING UNDER{" "}
           </Box>
-          <Box component="span" sx={BRAND_GRADIENT_TEXT_SX}>
+          <Box component="span" sx={{ color: ACCENT }}>
             ONE ROOF
           </Box>
         </Typography>
         <Typography
           sx={{
             fontSize: { xs: "16px", md: "20px" },
-            color: "rgba(255,255,255,0.8)",
+            color: "rgba(17,17,17,0.75)",
             maxWidth: 720,
             mx: "auto",
             mb: { xs: 6, md: 8 },
@@ -84,10 +84,8 @@ export default function BrandActivationsProcess() {
               >
                 <Box
                   sx={{
+                    ...NB_CARD_SX,
                     p: { xs: 3, md: 4 },
-                    border: "1px solid rgba(229,199,103,0.2)",
-                    borderRadius: 3,
-                    bgcolor: "rgba(229,199,103,0.04)",
                     height: "100%",
                     display: "flex",
                     flexDirection: "column",
@@ -95,7 +93,21 @@ export default function BrandActivationsProcess() {
                     textAlign: "center",
                   }}
                 >
-                  <Icon sx={{ fontSize: 48, color: "#E5C767", mb: 2 }} />
+                  <Box
+                    sx={{
+                      width: 72,
+                      height: 72,
+                      bgcolor: ACCENT,
+                      border: NB_BORDER,
+                      boxShadow: nbShadow(4),
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      mb: 2.5,
+                    }}
+                  >
+                    <Icon sx={{ fontSize: 40, color: INK }} />
+                  </Box>
                   <Typography
                     sx={{
                       fontSize: { xs: "20px", md: "24px" },
@@ -109,7 +121,7 @@ export default function BrandActivationsProcess() {
                   <Typography
                     sx={{
                       fontSize: { xs: "15px", md: "16px" },
-                      color: "rgba(255,255,255,0.8)",
+                      color: "rgba(17,17,17,0.75)",
                     }}
                   >
                     {step.desc}

--- a/app/brand-activations/CaseStudiesSection.tsx
+++ b/app/brand-activations/CaseStudiesSection.tsx
@@ -4,7 +4,15 @@ import { useEffect, useRef, useState } from "react";
 import { Box, Typography, useMediaQuery, useTheme } from "@mui/material";
 import Image from "next/image";
 import { motion, useInView } from "framer-motion";
-import { BRAND_GRADIENT_TEXT_SX } from "@/lib/theme";
+import {
+  ACCENT,
+  INK,
+  NB_CARD_DARK_SX,
+  PAPER,
+  POP,
+  SURFACE,
+  nbShadow,
+} from "@/lib/theme";
 
 // Metrics below reflect real numbers where available. LESGC reach is estimated
 // (see note field on the hero). Southside has no quantitative data yet, so the
@@ -45,7 +53,7 @@ type CaseStudy = {
   stats?: StatTile[];
 };
 
-const DONUT_COLORS = ["#E5C767", "#E89B3C", "#C9A227", "#D97706"];
+const DONUT_COLORS = [ACCENT, POP, PAPER, SURFACE];
 
 const CASE_STUDIES: CaseStudy[] = [
   {
@@ -188,7 +196,7 @@ function HeroMetricView({
     fontWeight: 900,
     lineHeight: 1,
     letterSpacing: "-0.03em",
-    ...BRAND_GRADIENT_TEXT_SX,
+    color: ACCENT,
   } as const;
 
   const count = useCountUp(
@@ -214,8 +222,8 @@ function HeroMetricView({
             ...headlineSx,
             textDecoration: "none",
             display: "inline-block",
-            transition: "filter 0.2s",
-            "&:hover": { filter: "brightness(1.1)" },
+            transition: "color 0.2s",
+            "&:hover": { color: POP },
           }}
         >
           {metric.value}
@@ -301,7 +309,7 @@ function DonutChart({
             cy={center}
             r={radius}
             fill="none"
-            stroke="rgba(255,255,255,0.08)"
+            stroke="#333333"
             strokeWidth={strokeWidth}
           />
           {arcs.map((arc) => (
@@ -350,7 +358,7 @@ function DonutChart({
                 width: 10,
                 height: 10,
                 bgcolor: arc.color,
-                borderRadius: "2px",
+                border: `1px solid ${PAPER}`,
                 flexShrink: 0,
               }}
             />
@@ -385,9 +393,10 @@ function StatCluster({ stats }: { stats: StatTile[] }) {
           key={s.label}
           sx={{
             p: 2,
-            border: "1px solid rgba(229,199,103,0.25)",
-            borderRadius: 2,
-            bgcolor: "rgba(229,199,103,0.04)",
+            border: `2px solid ${PAPER}`,
+            borderRadius: 0,
+            bgcolor: INK,
+            boxShadow: nbShadow(3, ACCENT),
             textAlign: "center",
           }}
         >
@@ -395,7 +404,7 @@ function StatCluster({ stats }: { stats: StatTile[] }) {
             sx={{
               fontSize: { xs: "22px", md: "28px" },
               fontWeight: 800,
-              ...BRAND_GRADIENT_TEXT_SX,
+              color: ACCENT,
             }}
           >
             {s.value}
@@ -426,11 +435,8 @@ function CaseStudyCard({ study }: { study: CaseStudy }) {
   return (
     <Box
       sx={{
+        ...NB_CARD_DARK_SX,
         p: { xs: 2.5, md: 4 },
-        border: "1px solid rgba(229,199,103,0.15)",
-        borderRadius: "24px",
-        background:
-          "linear-gradient(180deg, rgba(229,199,103,0.03) 0%, rgba(0,0,0,0) 100%)",
       }}
     >
       <Box
@@ -450,10 +456,11 @@ function CaseStudyCard({ study }: { study: CaseStudy }) {
             aspectRatio: study.youtubeId
               ? "16 / 9"
               : { xs: "4 / 3", md: "5 / 4" },
-            borderRadius: "18px",
+            border: `3px solid ${PAPER}`,
+            borderRadius: 0,
             overflow: "hidden",
-            boxShadow: "0 20px 60px rgba(0,0,0,0.5)",
-            bgcolor: "black",
+            boxShadow: nbShadow(6, ACCENT),
+            bgcolor: INK,
           }}
         >
           {study.youtubeId ? (
@@ -498,7 +505,7 @@ function CaseStudyCard({ study }: { study: CaseStudy }) {
                 lineHeight: 1,
                 fontWeight: 900,
                 letterSpacing: "-0.04em",
-                ...BRAND_GRADIENT_TEXT_SX,
+                color: ACCENT,
               }}
             >
               {study.number}
@@ -555,7 +562,7 @@ function CaseStudyCard({ study }: { study: CaseStudy }) {
         sx={{
           mt: { xs: 4, md: 5 },
           pt: { xs: 3, md: 4 },
-          borderTop: "1px solid rgba(229,199,103,0.2)",
+          borderTop: `2px solid ${PAPER}`,
           display: "grid",
           gridTemplateColumns: { xs: "1fr", md: "auto 1fr" },
           gap: { xs: 4, md: 6 },
@@ -581,7 +588,7 @@ export default function CaseStudiesSection() {
     <Box
       id="case-studies"
       sx={{
-        bgcolor: "black",
+        bgcolor: INK,
         color: "white",
         px: { xs: 2, md: 6 },
         py: { xs: 8, md: 14 },
@@ -595,14 +602,13 @@ export default function CaseStudiesSection() {
             component="h2"
             sx={{
               fontSize: { xs: "34px", md: "56px", lg: "68px" },
-              fontWeight: "bold",
               mb: 2,
             }}
           >
             <Box component="span" sx={{ color: "white" }}>
               SELECTED{" "}
             </Box>
-            <Box component="span" sx={BRAND_GRADIENT_TEXT_SX}>
+            <Box component="span" sx={{ color: ACCENT }}>
               WORK
             </Box>
           </Typography>

--- a/app/brand-activations/page.tsx
+++ b/app/brand-activations/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Box } from "@mui/material";
+import { INK } from "@/lib/theme";
 import TrustWall, { TrustPress } from "../components/TrustWall";
 import SocialProofBar from "../components/SocialProofBar";
 import Footer from "../ui/Footer";
@@ -49,7 +50,7 @@ export const metadata: Metadata = {
 
 export default function BrandActivationsPage() {
   return (
-    <Box sx={{ bgcolor: "black" }}>
+    <Box sx={{ bgcolor: INK }}>
       <BrandActivationsServiceJsonLd />
       <PageViewTracker />
       <BrandActivationsHero />

--- a/app/components/AboutUs.tsx
+++ b/app/components/AboutUs.tsx
@@ -3,12 +3,13 @@
 import { useRef } from "react";
 import { Box, Typography } from "@mui/material";
 import { motion } from "framer-motion";
+import { ACCENT, INK } from "@/lib/theme";
 
 export default function AboutUs() {
   const ref = useRef(null);
 
   return (
-    <Box ref={ref} sx={{ bgcolor: "black" }}>
+    <Box ref={ref} sx={{ bgcolor: INK }}>
       <Box
         sx={{
           width: "100%",
@@ -26,7 +27,6 @@ export default function AboutUs() {
             color="white"
             sx={{
               fontSize: { xs: "55px", sm: "95px" },
-              fontWeight: "bold",
               paddingTop: { xs: 8 },
               marginBottom: { xs: "20px", md: "30px" },
               paddingLeft: "10px",
@@ -55,7 +55,7 @@ export default function AboutUs() {
                 textAlign: "center",
               }}
             >
-              <Box component="span" sx={{ color: "#E5C767", fontWeight: 600 }}>
+              <Box component="span" sx={{ color: ACCENT, fontWeight: 700 }}>
                 Drip Dome Productions
               </Box>{" "}
               is a majority women-owned, family-run business based in New York

--- a/app/components/Chatbot.tsx
+++ b/app/components/Chatbot.tsx
@@ -7,6 +7,15 @@ import { Box, IconButton, Typography, TextField, Chip } from "@mui/material";
 import ChatIcon from "@mui/icons-material/Chat";
 import CloseIcon from "@mui/icons-material/Close";
 import SendIcon from "@mui/icons-material/Send";
+import {
+  ACCENT,
+  INK,
+  NB_BORDER,
+  NB_BORDER_THIN,
+  PAPER,
+  SURFACE,
+  nbShadow,
+} from "@/lib/theme";
 
 const QUICK_QUESTIONS = [
   "What services does DripDome offer?",
@@ -75,11 +84,21 @@ export default function Chatbot() {
             zIndex: 1300,
             width: 56,
             height: 56,
-            bgcolor: "#E5C767",
-            color: "#FFFFFF",
-            boxShadow: "0 4px 20px rgba(229,199,103,0.4)",
-            "&:hover": { bgcolor: "#111111" },
-            transition: "background-color 0.2s",
+            borderRadius: 0,
+            bgcolor: ACCENT,
+            color: INK,
+            border: NB_BORDER,
+            boxShadow: nbShadow(4),
+            transition: "transform 120ms ease, box-shadow 120ms ease",
+            "&:hover": {
+              bgcolor: ACCENT,
+              transform: "translate(-2px, -2px)",
+              boxShadow: nbShadow(6),
+            },
+            "&:active": {
+              transform: "translate(2px, 2px)",
+              boxShadow: nbShadow(0),
+            },
           }}
         >
           <ChatIcon />
@@ -98,9 +117,10 @@ export default function Chatbot() {
             maxHeight: { xs: "70vh", sm: 520 },
             display: "flex",
             flexDirection: "column",
-            bgcolor: "#FFFFFF",
-            borderRadius: 3,
-            boxShadow: "0 8px 40px rgba(0,0,0,0.2)",
+            bgcolor: SURFACE,
+            border: NB_BORDER,
+            borderRadius: 0,
+            boxShadow: nbShadow(8),
             overflow: "hidden",
           }}
         >
@@ -112,8 +132,9 @@ export default function Chatbot() {
               justifyContent: "space-between",
               px: 2,
               py: 1.5,
-              bgcolor: "#111111",
-              color: "#FFFFFF",
+              bgcolor: INK,
+              color: PAPER,
+              borderBottom: `3px solid ${ACCENT}`,
               flexShrink: 0,
             }}
           >
@@ -121,7 +142,7 @@ export default function Chatbot() {
               <Typography sx={{ fontWeight: 700, fontSize: 14, letterSpacing: "0.05em" }}>
                 NOVA
               </Typography>
-              <Typography sx={{ fontSize: 10, color: "#999", letterSpacing: "0.03em" }}>
+              <Typography sx={{ fontSize: 10, color: "rgba(243,237,226,0.7)", letterSpacing: "0.03em" }}>
                 DripDome&apos;s AI Assistant
               </Typography>
             </Box>
@@ -129,7 +150,7 @@ export default function Chatbot() {
               onClick={() => setOpen(false)}
               size="small"
               aria-label="Close chat"
-              sx={{ color: "#FFFFFF", "&:hover": { color: "#E5C767" } }}
+              sx={{ color: PAPER, borderRadius: 0, "&:hover": { color: ACCENT } }}
             >
               <CloseIcon fontSize="small" />
             </IconButton>
@@ -165,12 +186,14 @@ export default function Chatbot() {
                         height: "auto",
                         py: 0.5,
                         "& .MuiChip-label": { whiteSpace: "normal", lineHeight: 1.3 },
-                        bgcolor: "#F5F5F5",
-                        color: "#111111",
-                        border: "1px solid #E0E0E0",
+                        bgcolor: SURFACE,
+                        color: INK,
+                        border: NB_BORDER_THIN,
+                        borderRadius: 0,
+                        fontWeight: 700,
                         cursor: "pointer",
-                        "&:hover": { bgcolor: "#111111", color: "#FFFFFF" },
-                        transition: "all 0.15s",
+                        "&:hover": { bgcolor: ACCENT, color: INK },
+                        transition: "background-color 0.15s, color 0.15s",
                       }}
                     />
                   ))}
@@ -197,9 +220,9 @@ export default function Chatbot() {
                     sx={{
                       px: 1.5,
                       py: 1,
-                      borderRadius: 2,
-                      bgcolor: m.role === "user" ? "#111111" : "#F5F5F5",
-                      color: m.role === "user" ? "#FFFFFF" : "#111111",
+                      border: NB_BORDER_THIN,
+                      bgcolor: m.role === "user" ? INK : PAPER,
+                      color: m.role === "user" ? PAPER : INK,
                     }}
                   >
                     <Typography sx={{ fontSize: 13, lineHeight: 1.5, whiteSpace: "pre-wrap" }}>
@@ -214,7 +237,7 @@ export default function Chatbot() {
                 <Typography sx={{ fontSize: 10, color: "#999", mb: 0.25, ml: 0.5 }}>
                   Nova
                 </Typography>
-                <Box sx={{ px: 1.5, py: 1, borderRadius: 2, bgcolor: "#F5F5F5" }}>
+                <Box sx={{ px: 1.5, py: 1, border: NB_BORDER_THIN, bgcolor: PAPER, color: INK }}>
                   <Typography sx={{ fontSize: 13, lineHeight: 1.5 }}>
                     {errorMsg}
                   </Typography>
@@ -226,7 +249,7 @@ export default function Chatbot() {
                 <Typography sx={{ fontSize: 10, color: "#999", mb: 0.25, ml: 0.5 }}>
                   Nova
                 </Typography>
-                <Box sx={{ px: 1.5, py: 1, borderRadius: 2, bgcolor: "#F5F5F5" }}>
+                <Box sx={{ px: 1.5, py: 1, border: NB_BORDER_THIN, bgcolor: PAPER }}>
                   <Typography sx={{ fontSize: 13, color: "#888" }}>...</Typography>
                 </Box>
               </Box>
@@ -244,7 +267,7 @@ export default function Chatbot() {
               gap: 1,
               px: 1.5,
               py: 1.5,
-              borderTop: "1px solid #E0E0E0",
+              borderTop: NB_BORDER_THIN,
               flexShrink: 0,
             }}
           >
@@ -258,7 +281,13 @@ export default function Chatbot() {
               sx={{
                 "& .MuiOutlinedInput-root": {
                   fontSize: 13,
-                  borderRadius: 2,
+                  borderRadius: 0,
+                  "& fieldset": { border: NB_BORDER_THIN },
+                  "&:hover fieldset": { border: NB_BORDER_THIN },
+                  "&.Mui-focused fieldset": {
+                    border: `2px solid ${ACCENT}`,
+                  },
+                  "&.Mui-focused": { boxShadow: nbShadow(3) },
                 },
               }}
             />
@@ -267,8 +296,9 @@ export default function Chatbot() {
               disabled={isLoading || !input.trim()}
               aria-label="Send message"
               sx={{
-                color: "#111111",
-                "&:hover": { color: "#E5C767" },
+                color: INK,
+                borderRadius: 0,
+                "&:hover": { color: ACCENT },
                 "&.Mui-disabled": { color: "#CCC" },
               }}
             >

--- a/app/components/Contact.tsx
+++ b/app/components/Contact.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Box, Typography } from "@mui/material";
+import { ACCENT, INK, PAPER } from "@/lib/theme";
 import Footer from "../ui/Footer";
 import ContactForm from "./ContactForm";
 
@@ -13,6 +14,10 @@ export default function Contact() {
           flexDirection: "column",
           alignItems: "center",
           px: { xs: 4, md: 8 },
+          py: { xs: 6, md: 8 },
+          bgcolor: PAPER,
+          borderTop: `4px solid ${ACCENT}`,
+          borderBottom: `4px solid ${INK}`,
         }}
       >
         <Typography
@@ -20,11 +25,10 @@ export default function Contact() {
           component="h2"
           sx={{
             fontSize: { xs: "50px", md: "80px", lg: "90px" },
-            fontWeight: "bold",
             marginBottom: "15px",
             justifyContent: "center",
             display: "flex",
-            color: "white",
+            color: INK,
             whiteSpace: "nowrap",
           }}
         >
@@ -40,7 +44,7 @@ export default function Contact() {
             textAlign: "center",
             maxWidth: 900,
             marginBottom: "30px",
-            color: "white",
+            color: INK,
           }}
         >
           Big or small, every idea has the potential to shine. Tell us about

--- a/app/components/ContactForm.tsx
+++ b/app/components/ContactForm.tsx
@@ -4,6 +4,31 @@ import { useRef, FormEvent } from "react";
 import { Box, Button, TextField } from "@mui/material";
 import ReCAPTCHA from "react-google-recaptcha";
 import { sendData } from "@/hooks/sendData";
+import {
+  ACCENT,
+  INK,
+  NB_BORDER,
+  NB_BUTTON_SX,
+  SURFACE,
+  nbShadow,
+} from "@/lib/theme";
+
+const inputSx = {
+  "& .MuiOutlinedInput-root": {
+    bgcolor: SURFACE,
+    color: INK,
+    borderRadius: 0,
+    transition: "box-shadow 120ms ease",
+    "& fieldset": { border: NB_BORDER },
+    "&:hover fieldset": { border: NB_BORDER },
+    "&.Mui-focused fieldset": { border: `3px solid ${ACCENT}` },
+    "&.Mui-focused": { boxShadow: nbShadow(4) },
+  },
+  "& .MuiInputBase-input::placeholder": {
+    color: "rgba(17,17,17,0.6)",
+    opacity: 1,
+  },
+} as const;
 
 export default function ContactForm() {
   const recaptchaRef = useRef<ReCAPTCHA>(null);
@@ -74,13 +99,7 @@ export default function ContactForm() {
         required
         fullWidth
         inputProps={{ "aria-label": "Name" }}
-        sx={{
-          "& .MuiInputBase-root": { bgcolor: "white", color: "black" },
-          "& .MuiInputBase-input::placeholder": {
-            color: "rgba(0,0,0,0.7)",
-            opacity: 1,
-          },
-        }}
+        sx={inputSx}
       />
       <TextField
         name="instagram"
@@ -88,13 +107,7 @@ export default function ContactForm() {
         required
         fullWidth
         inputProps={{ "aria-label": "Instagram" }}
-        sx={{
-          "& .MuiInputBase-root": { bgcolor: "white", color: "black" },
-          "& .MuiInputBase-input::placeholder": {
-            color: "rgba(0,0,0,0.7)",
-            opacity: 1,
-          },
-        }}
+        sx={inputSx}
       />
       <TextField
         name="email"
@@ -103,13 +116,7 @@ export default function ContactForm() {
         required
         fullWidth
         inputProps={{ "aria-label": "Email" }}
-        sx={{
-          "& .MuiInputBase-root": { bgcolor: "white", color: "black" },
-          "& .MuiInputBase-input::placeholder": {
-            color: "rgba(0,0,0,0.7)",
-            opacity: 1,
-          },
-        }}
+        sx={inputSx}
       />
       <TextField
         name="referral"
@@ -117,13 +124,7 @@ export default function ContactForm() {
         required
         fullWidth
         inputProps={{ "aria-label": "How did you hear about us" }}
-        sx={{
-          "& .MuiInputBase-root": { bgcolor: "white", color: "black" },
-          "& .MuiInputBase-input::placeholder": {
-            color: "rgba(0,0,0,0.7)",
-            opacity: 1,
-          },
-        }}
+        sx={inputSx}
       />
       <TextField
         name="message"
@@ -133,13 +134,7 @@ export default function ContactForm() {
         multiline
         minRows={4}
         inputProps={{ "aria-label": "Message" }}
-        sx={{
-          "& .MuiInputBase-root": { bgcolor: "white", color: "black" },
-          "& .MuiInputBase-input::placeholder": {
-            color: "rgba(0,0,0,0.7)",
-            opacity: 1,
-          },
-        }}
+        sx={inputSx}
       />
       <Box sx={{ mb: 1, display: "flex", justifyContent: "center" }}>
         <ReCAPTCHA
@@ -150,15 +145,15 @@ export default function ContactForm() {
       <Button
         type="submit"
         variant="contained"
+        disableElevation
         sx={{
           alignSelf: "center",
           px: 4,
           py: 1.5,
           width: "80dvw",
           maxWidth: 900,
-          fontWeight: 700,
-          bgcolor: "#16a34a",
-          "&:hover": { bgcolor: "#1d4ed8" },
+          letterSpacing: "0.08em",
+          ...NB_BUTTON_SX,
         }}
       >
         SEND

--- a/app/components/FeaturedProjects.tsx
+++ b/app/components/FeaturedProjects.tsx
@@ -5,7 +5,7 @@ import { Swiper, SwiperSlide } from "swiper/react";
 import "swiper/css";
 import Image from "next/image";
 import { Autoplay, EffectCards } from "swiper/modules";
-import { BRAND_GRADIENT_TEXT_SX } from "@/lib/theme";
+import { ACCENT, INK, PAPER, nbShadow } from "@/lib/theme";
 
 const sections = [
   {
@@ -73,7 +73,6 @@ const FeaturedProjects = () => {
         <Box
           key={index}
           sx={{
-            borderRadius: 4,
             pt: { md: 8, lg: 8 },
             mb: 6,
           }}
@@ -91,9 +90,9 @@ const FeaturedProjects = () => {
               width: "100%",
               gap: "1.5rem",
               overflow: "hidden",
-              border: "4px solid rgba(229, 199, 103, 0.3)",
-              borderRadius: "30px",
-              backgroundColor: "#121212",
+              border: `3px solid ${PAPER}`,
+              backgroundColor: INK,
+              boxShadow: nbShadow(8, ACCENT),
               paddingTop: {
                 xs: "20px",
                 sm: "20px",
@@ -148,7 +147,7 @@ const FeaturedProjects = () => {
                   perSlideOffset: 8,
                   perSlideRotate: 2,
                   rotate: true,
-                  slideShadows: true,
+                  slideShadows: false,
                 }}
                 modules={[EffectCards, Autoplay]}
                 style={{ width: "100%" }}
@@ -172,9 +171,9 @@ const FeaturedProjects = () => {
                           lg: "600px",
                         },
                         position: "relative",
-                        borderRadius: "15px",
                         overflow: "hidden",
-                        boxShadow: "0px 5px 20px rgba(0, 0, 0, 0.3)",
+                        bgcolor: INK,
+                        border: `3px solid ${PAPER}`,
                       }}
                     >
                       <Image
@@ -184,7 +183,6 @@ const FeaturedProjects = () => {
                         sizes="(max-width: 600px) 90vw, (max-width: 900px) 40vw, 40vw"
                         style={{
                           objectFit: "contain",
-                          borderRadius: "15px",
                         }}
                       />
                     </Box>
@@ -209,7 +207,7 @@ const FeaturedProjects = () => {
                   fontSize: { xs: "28px", sm: "36px", md: "40px", lg: "50px" },
                   mb: "1.5rem",
                   color: "white",
-                  "& span": BRAND_GRADIENT_TEXT_SX,
+                  "& span": { color: ACCENT },
                 }}
               >
                 {section.header}
@@ -218,7 +216,7 @@ const FeaturedProjects = () => {
                 variant="body1"
                 sx={{
                   fontSize: { xs: "14px", sm: "18px", md: "20px" },
-                  color: "#e0e0e0",
+                  color: "rgba(243,237,226,0.85)",
                 }}
               >
                 {section.blurb}

--- a/app/components/FoundersSection.tsx
+++ b/app/components/FoundersSection.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { Box, Typography, useMediaQuery, useTheme } from "@mui/material";
 import Image from "next/image";
 import { motion } from "framer-motion";
+import { ACCENT, INK, PAPER, nbShadow } from "@/lib/theme";
 
 const founders = [
   {
@@ -31,18 +32,18 @@ const FoundersSection = () => {
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
 
   return (
-    <Box sx={{ bgcolor: "black" }}>
+    <Box sx={{ bgcolor: INK }}>
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ delay: 0, duration: 0.5 }}
       >
-        <Box sx={{ pt: 12, bgcolor: "black" }}>
+        <Box sx={{ pt: 12, bgcolor: INK }}>
           <Box
             sx={{
               paddingTop: "0px",
               textAlign: "center",
-              background: "black",
+              background: INK,
             }}
           >
             {/* <Typography
@@ -65,7 +66,7 @@ const FoundersSection = () => {
             <Box
               sx={{
                 padding: "2rem",
-                backgroundColor: "black",
+                backgroundColor: INK,
               }}
             >
               <Box
@@ -97,7 +98,8 @@ const FoundersSection = () => {
                         sx={{
                           width: { xs: 192, lg: 288 },
                           height: { xs: 192, lg: 288 },
-                          borderRadius: "50%",
+                          border: `3px solid ${PAPER}`,
+                          boxShadow: nbShadow(6, ACCENT),
                           overflow: "hidden",
                           display: "flex",
                           justifyContent: "center",
@@ -131,8 +133,8 @@ const FoundersSection = () => {
                             content: '""',
                             display: "block",
                             width: "40px",
-                            height: "2px",
-                            bgcolor: "#E5C767",
+                            height: "3px",
+                            bgcolor: ACCENT,
                             mx: "auto",
                             mt: 1,
                           },

--- a/app/components/HomeBlurb.tsx
+++ b/app/components/HomeBlurb.tsx
@@ -7,7 +7,13 @@ import { motion, useInView } from "framer-motion";
 import WomanIcon from "@mui/icons-material/Woman";
 import Diversity3Icon from "@mui/icons-material/Diversity3";
 import AirplaneTicketIcon from "@mui/icons-material/AirplaneTicket";
-import { BRAND_GRADIENT } from "@/lib/theme";
+import {
+  ACCENT,
+  INK,
+  NB_BUTTON_OUTLINE_DARK_SX,
+  NB_BUTTON_SX,
+  NB_TAG_DARK_SX,
+} from "@/lib/theme";
 export default function HomeBlurb() {
   const ref = useRef(null);
   const isInView = useInView(ref, { once: true }); // Trigger once when in view
@@ -36,57 +42,35 @@ export default function HomeBlurb() {
   ] as const;
 
   const badgeSx = {
-    borderRadius: 999,
+    ...NB_TAG_DARK_SX,
     px: 1.25,
     py: 0.5,
     minHeight: 0,
-    borderColor: "rgba(255,255,255,0.6)",
-    color: "common.white",
-    letterSpacing: "0.08em",
-    fontWeight: 700,
     zIndex: 10,
-
     fontSize: { xs: "10px", sm: "12px" },
     lineHeight: 1,
-    backgroundColor: "rgba(255,255,255,0.04)",
     "& .MuiButton-startIcon": { mr: 0.75 },
     "&:hover": {
-      borderColor: "rgba(255,255,255,0.85)",
-      backgroundColor: "rgba(255,255,255,0.08)",
+      bgcolor: INK,
+      borderColor: ACCENT,
+      color: ACCENT,
     },
   } as const;
 
   const ctaPrimarySx = {
-    borderRadius: 999,
+    ...NB_BUTTON_SX,
     px: { xs: 2, sm: 2.5 },
     py: { xs: 1, sm: 1.1 },
-    fontWeight: 800,
     letterSpacing: "0.08em",
     fontSize: { xs: "12px", sm: "13px" },
-    color: "black",
-    background: BRAND_GRADIENT,
-    boxShadow: "0 10px 30px rgba(229,199,103,0.25)",
-    "&:hover": {
-      background: BRAND_GRADIENT,
-      filter: "brightness(0.92)",
-      boxShadow: "0 12px 34px rgba(229,199,103,0.35)",
-    },
   } as const;
 
   const ctaSecondarySx = {
-    borderRadius: 999,
+    ...NB_BUTTON_OUTLINE_DARK_SX,
     px: { xs: 2, sm: 2.5 },
     py: { xs: 1, sm: 1.1 },
-    fontWeight: 800,
     letterSpacing: "0.08em",
     fontSize: { xs: "12px", sm: "13px" },
-    color: "common.white",
-    bgcolor: "rgba(255,255,255,0.12)",
-    border: "1px solid rgba(255,255,255,0.18)",
-    "&:hover": {
-      bgcolor: "rgba(255,255,255,0.18)",
-      borderColor: "rgba(255,255,255,0.28)",
-    },
   } as const;
 
   return (
@@ -113,7 +97,6 @@ export default function HomeBlurb() {
           color="primary"
           sx={{
             fontSize: { xs: "24px", sm: "60px", lg: "70px" },
-            fontWeight: "bold",
             color: "white",
           }}
         >

--- a/app/components/HomeFeaturedWork.tsx
+++ b/app/components/HomeFeaturedWork.tsx
@@ -6,6 +6,7 @@ import { Swiper, SwiperSlide } from "swiper/react";
 import "swiper/css";
 import Image from "next/image";
 import { Autoplay, EffectCards } from "swiper/modules";
+import { ACCENT, INK, PAPER, nbShadow } from "@/lib/theme";
 
 const S3 = "https://dripdome-site.s3.us-east-2.amazonaws.com";
 
@@ -53,20 +54,21 @@ export default function HomeFeaturedWork() {
         variant="h2"
         sx={{
           fontSize: { xs: "28px", sm: "45px", lg: "55px" },
-          fontWeight: "bold",
           color: "white",
           textAlign: "center",
           mb: { xs: 3, md: 5 },
         }}
       >
-        Featured Work
+        Featured{" "}
+        <Box component="span" sx={{ color: ACCENT }}>
+          Work
+        </Box>
       </Typography>
 
       {projects.map((section, index) => (
         <Box
           key={index}
           sx={{
-            borderRadius: 4,
             pt: { md: 4, lg: 4 },
             mb: 4,
           }}
@@ -84,9 +86,10 @@ export default function HomeFeaturedWork() {
               width: "100%",
               gap: "1.5rem",
               overflow: "hidden",
-              border: "4px solid rgba(229, 199, 103, 0.3)",
-              borderRadius: "30px",
-              backgroundColor: "#121212",
+              border: `3px solid ${PAPER}`,
+              borderRadius: 0,
+              backgroundColor: INK,
+              boxShadow: nbShadow(8, ACCENT),
               p: { xs: "20px 0 0 0", sm: "20px" },
             }}
           >
@@ -110,7 +113,7 @@ export default function HomeFeaturedWork() {
                   perSlideOffset: 8,
                   perSlideRotate: 2,
                   rotate: true,
-                  slideShadows: true,
+                  slideShadows: false,
                 }}
                 modules={[EffectCards, Autoplay]}
                 style={{ width: "100%" }}
@@ -134,9 +137,8 @@ export default function HomeFeaturedWork() {
                           lg: "600px",
                         },
                         position: "relative",
-                        borderRadius: "15px",
+                        borderRadius: 0,
                         overflow: "hidden",
-                        boxShadow: "0px 5px 20px rgba(0, 0, 0, 0.3)",
                       }}
                     >
                       <Image
@@ -144,7 +146,7 @@ export default function HomeFeaturedWork() {
                         alt={section.header}
                         fill
                         sizes="(max-width: 600px) 90vw, 40vw"
-                        style={{ objectFit: "contain", borderRadius: "15px" }}
+                        style={{ objectFit: "contain" }}
                       />
                     </Box>
                   </SwiperSlide>
@@ -167,7 +169,6 @@ export default function HomeFeaturedWork() {
                   fontSize: { xs: "24px", sm: "32px", md: "36px", lg: "44px" },
                   mb: "1.5rem",
                   color: "white",
-                  fontWeight: "bold",
                 }}
               >
                 {section.header}
@@ -176,7 +177,7 @@ export default function HomeFeaturedWork() {
                 variant="body1"
                 sx={{
                   fontSize: { xs: "14px", sm: "18px", md: "20px" },
-                  color: "#e0e0e0",
+                  color: PAPER,
                 }}
               >
                 {section.blurb}
@@ -191,12 +192,16 @@ export default function HomeFeaturedWork() {
           component={Link}
           href="/portfolio"
           sx={{
-            color: "#E5C767",
+            display: "inline-block",
+            color: ACCENT,
             fontSize: { xs: "14px", sm: "16px" },
             fontWeight: 700,
             letterSpacing: "0.06em",
+            textTransform: "uppercase",
             textDecoration: "none",
-            "&:hover": { textDecoration: "underline" },
+            px: 1,
+            py: 0.5,
+            "&:hover": { bgcolor: ACCENT, color: INK },
           }}
         >
           See All Projects &rarr;

--- a/app/components/HomeHero.tsx
+++ b/app/components/HomeHero.tsx
@@ -5,8 +5,12 @@ import Image from "next/image";
 import Link from "next/link";
 import { motion } from "framer-motion";
 import {
-  BRAND_GRADIENT_BUTTON_SX,
-  BRAND_GRADIENT_TEXT_SX,
+  ACCENT,
+  INK,
+  NB_BUTTON_OUTLINE_DARK_SX,
+  NB_BUTTON_SX,
+  NB_TAG_DARK_SX,
+  nbShadow,
 } from "@/lib/theme";
 
 // TODO: replace hero image with a 15s branded reel once produced
@@ -27,7 +31,8 @@ export default function HomeHero() {
         display: "flex",
         alignItems: "center",
         justifyContent: "center",
-        bgcolor: "black",
+        bgcolor: INK,
+        borderBottom: `6px solid ${ACCENT}`,
         pt: { xs: "95px", md: "40px" },
       }}
     >
@@ -43,8 +48,7 @@ export default function HomeHero() {
         sx={{
           position: "absolute",
           inset: 0,
-          background:
-            "linear-gradient(180deg, rgba(0,0,0,0.35) 0%, rgba(0,0,0,0.85) 100%)",
+          bgcolor: "rgba(17,17,17,0.55)",
         }}
       />
 
@@ -77,15 +81,8 @@ export default function HomeHero() {
               <Box
                 key={badge}
                 sx={{
-                  px: 2,
-                  py: 0.75,
-                  border: "1px solid rgba(229,199,103,0.6)",
-                  borderRadius: "999px",
+                  ...NB_TAG_DARK_SX,
                   fontSize: { xs: "11px", md: "13px" },
-                  fontWeight: 600,
-                  letterSpacing: "0.1em",
-                  color: "white",
-                  bgcolor: "rgba(229,199,103,0.08)",
                 }}
               >
                 {badge}
@@ -104,21 +101,32 @@ export default function HomeHero() {
             component="h1"
             sx={{
               fontSize: {
-                xs: "40px",
-                sm: "56px",
-                md: "64px",
-                lg: "72px",
-                xl: "96px",
+                xs: "38px",
+                sm: "52px",
+                md: "60px",
+                lg: "68px",
+                xl: "88px",
               },
-              fontWeight: "bold",
-              lineHeight: 1.05,
+              lineHeight: 1.1,
               color: "white",
               mb: { xs: 3, lg: 2.5, xl: 3 },
             }}
           >
             WE BUILD WORLDS.
             <br />
-            <Box component="span" sx={BRAND_GRADIENT_TEXT_SX}>
+            <Box
+              component="span"
+              sx={{
+                display: "inline-block",
+                bgcolor: ACCENT,
+                color: INK,
+                px: { xs: 1.5, md: 3 },
+                py: { xs: 0.5, md: 1 },
+                mt: { xs: 1.5, md: 2 },
+                boxShadow: nbShadow(8),
+                transform: "rotate(-1.5deg)",
+              }}
+            >
               SETS. STAGES. STORIES.
             </Box>
           </Typography>
@@ -160,13 +168,13 @@ export default function HomeHero() {
               component={Link}
               href="/portfolio"
               variant="contained"
+              disableElevation
               sx={{
                 px: 4,
                 py: 1.75,
                 fontSize: { xs: "14px", md: "16px" },
-                fontWeight: 700,
                 letterSpacing: "0.08em",
-                ...BRAND_GRADIENT_BUTTON_SX,
+                ...NB_BUTTON_SX,
               }}
             >
               VIEW PORTFOLIO
@@ -185,14 +193,8 @@ export default function HomeHero() {
                 px: 4,
                 py: 1.75,
                 fontSize: { xs: "14px", md: "16px" },
-                fontWeight: 700,
                 letterSpacing: "0.08em",
-                color: "white",
-                borderColor: "rgba(255,255,255,0.6)",
-                "&:hover": {
-                  borderColor: "white",
-                  bgcolor: "rgba(255,255,255,0.08)",
-                },
+                ...NB_BUTTON_OUTLINE_DARK_SX,
               }}
             >
               START A PROJECT

--- a/app/components/HowWeWork.tsx
+++ b/app/components/HowWeWork.tsx
@@ -3,7 +3,7 @@
 import { useRef } from "react";
 import { Box, Button, Typography } from "@mui/material";
 import { motion, useInView } from "framer-motion";
-import { BRAND_GRADIENT } from "@/lib/theme";
+import { ACCENT, INK, NB_BUTTON_SX, PAPER, nbShadow } from "@/lib/theme";
 
 const steps = [
   {
@@ -43,13 +43,15 @@ export default function HowWeWork() {
         variant="h2"
         sx={{
           fontSize: { xs: "28px", sm: "40px", lg: "50px" },
-          fontWeight: "bold",
           color: "white",
           textAlign: "center",
           mb: { xs: 4, md: 6 },
         }}
       >
-        How We Work
+        How We{" "}
+        <Box component="span" sx={{ color: ACCENT }}>
+          Work
+        </Box>
       </Typography>
 
       <Box
@@ -80,23 +82,24 @@ export default function HowWeWork() {
                 pb: { xs: 3, md: 0 },
               }}
             >
-              {/* Step number circle */}
+              {/* Step number block */}
               <Box
                 sx={{
-                  width: 48,
-                  height: 48,
-                  minWidth: 48,
-                  borderRadius: "50%",
-                  border: "2px solid #E5C767",
+                  width: 52,
+                  height: 52,
+                  minWidth: 52,
+                  bgcolor: ACCENT,
+                  border: `2px solid ${PAPER}`,
+                  boxShadow: nbShadow(4, PAPER),
                   display: "flex",
                   alignItems: "center",
                   justifyContent: "center",
-                  mb: { md: 2 },
+                  mb: { md: 2.5 },
                 }}
               >
                 <Typography
                   sx={{
-                    color: "#E5C767",
+                    color: INK,
                     fontWeight: 800,
                     fontSize: "16px",
                   }}
@@ -112,10 +115,10 @@ export default function HowWeWork() {
                     display: { xs: "none", md: "block" },
                     position: "absolute",
                     top: 24,
-                    left: "calc(50% + 30px)",
-                    width: "calc(100% - 60px)",
-                    height: "2px",
-                    bgcolor: "rgba(229,199,103,0.25)",
+                    left: "calc(50% + 34px)",
+                    width: "calc(100% - 68px)",
+                    height: "3px",
+                    bgcolor: PAPER,
                   }}
                 />
               )}
@@ -126,11 +129,11 @@ export default function HowWeWork() {
                   sx={{
                     display: { xs: "block", md: "none" },
                     position: "absolute",
-                    top: 48,
-                    left: 23,
-                    width: "2px",
-                    height: "calc(100% - 48px)",
-                    bgcolor: "rgba(229,199,103,0.25)",
+                    top: 54,
+                    left: 24,
+                    width: "3px",
+                    height: "calc(100% - 54px)",
+                    bgcolor: PAPER,
                   }}
                 />
               )}
@@ -150,7 +153,7 @@ export default function HowWeWork() {
                 <Typography
                   sx={{
                     fontSize: { xs: "13px", sm: "14px" },
-                    color: "rgba(255,255,255,0.6)",
+                    color: "rgba(243,237,226,0.7)",
                   }}
                 >
                   {step.description}
@@ -168,20 +171,11 @@ export default function HowWeWork() {
           variant="contained"
           disableElevation
           sx={{
-            borderRadius: 999,
             px: 3,
-            py: 1.1,
-            fontWeight: 800,
+            py: 1.25,
             letterSpacing: "0.08em",
             fontSize: "13px",
-            color: "black",
-            background: BRAND_GRADIENT,
-            boxShadow: "0 10px 30px rgba(229,199,103,0.25)",
-            "&:hover": {
-              background: BRAND_GRADIENT,
-              filter: "brightness(0.92)",
-              boxShadow: "0 12px 34px rgba(229,199,103,0.35)",
-            },
+            ...NB_BUTTON_SX,
           }}
           onClick={(e: React.MouseEvent<HTMLAnchorElement>) => {
             e.preventDefault();

--- a/app/components/OurServices.tsx
+++ b/app/components/OurServices.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Box, Typography } from "@mui/material";
-import { GlareCard } from "@/components/ui/glare-card";
+import { ACCENT, INK, PAPER, nbShadow } from "@/lib/theme";
 
 const S3_BASE = "https://dripdome-site.s3.us-east-2.amazonaws.com";
 
@@ -22,6 +22,7 @@ export default function OurServices() {
       id="services"
       sx={{
         width: "100%",
+        bgcolor: INK,
         mb: 2,
         px: { xs: 2, md: 8 },
       }}
@@ -42,37 +43,51 @@ export default function OurServices() {
         }}
       >
         {services.map((service) => (
-          <GlareCard key={service.label}>
-            <Box
+          <Box
+            key={service.label}
+            sx={{
+              width: "100%",
+              maxWidth: { xs: 160, sm: 200, md: 280, lg: 340, xl: 400 },
+              aspectRatio: "17 / 21",
+              border: `3px solid ${PAPER}`,
+              borderRadius: 0,
+              boxShadow: nbShadow(6, ACCENT),
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              textAlign: "center",
+              p: 2,
+              backgroundImage: `url(${service.image})`,
+              backgroundSize: "cover",
+              backgroundPosition: "center",
+              transition: "transform 120ms ease, box-shadow 120ms ease",
+              "&:hover": {
+                transform: "translate(-2px, -2px)",
+                boxShadow: nbShadow(8, ACCENT),
+              },
+              "&:active": {
+                transform: "translate(2px, 2px)",
+                boxShadow: nbShadow(0, ACCENT),
+              },
+            }}
+          >
+            <Typography
+              component="span"
               sx={{
-                height: "100%",
-                width: "100%",
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                textAlign: "center",
-                p: 2,
-                backgroundImage: `url(${service.image})`,
-                backgroundSize: "cover",
-                backgroundPosition: "center",
+                color: PAPER,
+                fontWeight: 700,
+                letterSpacing: "0.12em",
+                textTransform: "uppercase",
+                fontSize: { xs: 14, sm: 18, md: 20 },
+                bgcolor: INK,
+                border: `2px solid ${PAPER}`,
+                boxShadow: nbShadow(3, ACCENT),
+                p: 1,
               }}
             >
-              <Typography
-                component="span"
-                sx={{
-                  color: "white",
-                  fontWeight: 800,
-                  letterSpacing: "0.12em",
-                  fontSize: { xs: 14, sm: 18, md: 20 },
-                  textShadow: "0 2px 8px rgba(0,0,0,0.8)",
-                  backgroundColor: "rgba(0,0,0,0.5)",
-                  p: 1,
-                }}
-              >
-                {service.label}
-              </Typography>
-            </Box>
-          </GlareCard>
+              {service.label}
+            </Typography>
+          </Box>
         ))}
       </Box>
     </Box>

--- a/app/components/PhotoPageCarousels.tsx
+++ b/app/components/PhotoPageCarousels.tsx
@@ -34,7 +34,6 @@ const PhotoPageCarousels: React.FC = () => {
               color="white"
               sx={{
                 fontSize: { xs: "30px", sm: "55px", lg: "70px" },
-                fontWeight: "bold",
                 paddingTop: { xs: "30px", sm: "50px", md: "80px" },
                 marginBottom: { xs: "20px", md: "30px", lg: "40px" },
                 paddingLeft: "10px",
@@ -46,9 +45,6 @@ const PhotoPageCarousels: React.FC = () => {
             </Typography>
             <Swiper
               key={index}
-              style={{
-                borderRadius: "20px",
-              }}
               loop={true}
               autoplay={{
                 delay: 0,
@@ -72,7 +68,6 @@ const PhotoPageCarousels: React.FC = () => {
                     height: "100%",
                     maxWidth: "500px",
                     aspectRatio: "1",
-                    borderRadius: "20px",
                   }}
                 >
                   <Image
@@ -106,7 +101,6 @@ const PhotoPageCarousels: React.FC = () => {
                 color="white"
                 sx={{
                   fontSize: { xs: "30px", sm: "55px", lg: "70px" },
-                  fontWeight: "bold",
                   paddingTop: { xs: "30px", md: "30px" },
                   marginBottom: { xs: "20px", md: "30px" },
                   paddingLeft: "10px",
@@ -129,9 +123,6 @@ const PhotoPageCarousels: React.FC = () => {
                 spaceBetween={40}
                 modules={[Autoplay]}
                 freeMode={true}
-                style={{
-                  borderRadius: "50px",
-                }}
               >
                 {section.images.map((image, idx) => (
                   <SwiperSlide

--- a/app/components/PressSection.tsx
+++ b/app/components/PressSection.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Box, Typography } from "@mui/material";
+import { ACCENT, INK, PAPER, SURFACE, nbShadow } from "@/lib/theme";
 
 const pressItems = [
   {
@@ -41,22 +42,32 @@ const PressSection = () => {
             fontSize: { xs: "30px", sm: "80px" },
           }}
         >
-          Our Work in the Press
+          Our Work in the{" "}
+          <Box component="span" sx={{ color: ACCENT }}>
+            Press
+          </Box>
         </Typography>
         {pressItems.map((item, index) => (
           <Box
             key={index}
             sx={{
               padding: 2,
-              border: "1px solid #ccc",
-              borderRadius: 1,
-              backgroundColor: "white",
+              border: `3px solid ${PAPER}`,
+              borderRadius: 0,
+              backgroundColor: SURFACE,
+              boxShadow: nbShadow(6, ACCENT),
               textAlign: "center",
-              color: "black",
-              transition: "all 0.3s ease",
+              color: INK,
+              transition: "transform 120ms ease, box-shadow 120ms ease",
               "&:hover": {
-                backgroundColor: "black",
-                color: "white",
+                backgroundColor: ACCENT,
+                color: INK,
+                transform: "translate(-2px, -2px)",
+                boxShadow: nbShadow(8, ACCENT),
+              },
+              "&:active": {
+                transform: "translate(2px, 2px)",
+                boxShadow: nbShadow(0, ACCENT),
               },
             }}
           >

--- a/app/components/ProjectsContributed.tsx
+++ b/app/components/ProjectsContributed.tsx
@@ -1,5 +1,6 @@
 import { Box, Typography } from "@mui/material";
 import Image from "next/image";
+import { INK } from "@/lib/theme";
 
 export default function ProjectsContributed() {
   return (
@@ -7,7 +8,7 @@ export default function ProjectsContributed() {
       sx={{
         zIndex: 10,
         width: "100%",
-        // border: "1px solid white",
+        bgcolor: INK,
         mb: 2,
         px: { xs: 2, md: 8 },
       }}
@@ -18,7 +19,6 @@ export default function ProjectsContributed() {
         color="white"
         sx={{
           fontSize: { xs: "24px", sm: "45px", lg: "50px" },
-          fontWeight: "bold",
           marginBottom: "15px",
           paddingLeft: "10px",
           paddingRight: "10px",
@@ -55,7 +55,7 @@ export default function ProjectsContributed() {
               width: "100%",
               maxWidth: { xs: 100, sm: 150, md: 200, lg: 250 },
               aspectRatio: "1 / 1",
-              borderRadius: 4,
+              borderRadius: 0,
               display: "flex",
               alignItems: "center",
               justifyContent: "center",

--- a/app/components/RentalGrid.tsx
+++ b/app/components/RentalGrid.tsx
@@ -11,6 +11,7 @@ import {
   Typography,
 } from "@mui/material";
 import { rentalEquipment, categories } from "../rentals/data";
+import { ACCENT, INK, NB_CARD_DARK_SX, PAPER, nbShadow } from "@/lib/theme";
 
 export default function RentalGrid() {
   const [selectedCategory, setSelectedCategory] = useState("All");
@@ -36,19 +37,29 @@ export default function RentalGrid() {
             key={cat}
             label={cat.toUpperCase()}
             onClick={() => setSelectedCategory(cat)}
-            variant={selectedCategory === cat ? "filled" : "outlined"}
-            color={selectedCategory === cat ? "primary" : "default"}
             sx={{
-              bgcolor: selectedCategory === cat ? "#E5C767" : "black",
-              color: "white",
-              borderColor:
-                selectedCategory === cat ? "#E5C767" : "rgba(255,255,255,0.3)",
+              borderRadius: 0,
+              fontWeight: 700,
+              letterSpacing: "0.06em",
+              border: `2px solid ${PAPER}`,
+              bgcolor: selectedCategory === cat ? ACCENT : INK,
+              color: selectedCategory === cat ? INK : PAPER,
+              boxShadow:
+                selectedCategory === cat ? nbShadow(3, PAPER) : "none",
+              transition: "transform 120ms ease, box-shadow 120ms ease",
               "&:hover": {
-                bgcolor:
-                  selectedCategory === cat
-                    ? "#d1008f"
-                    : "rgba(229, 199, 103, 0.1)",
-                borderColor: "#E5C767",
+                bgcolor: selectedCategory === cat ? ACCENT : INK,
+                color: selectedCategory === cat ? INK : ACCENT,
+                borderColor: ACCENT,
+                transform: "translate(-2px, -2px)",
+                boxShadow: nbShadow(
+                  3,
+                  selectedCategory === cat ? PAPER : ACCENT,
+                ),
+              },
+              "&:active": {
+                transform: "translate(2px, 2px)",
+                boxShadow: "none",
               },
             }}
           />
@@ -64,13 +75,13 @@ export default function RentalGrid() {
                 width: "100%",
                 display: "flex",
                 flexDirection: "column",
-                backgroundColor: "rgba(100, 100, 100, 0.5)",
                 justifyContent: "center",
                 alignItems: "center",
-                transition: "box-shadow 0.3s ease",
-                borderRadius: "10px",
+                ...NB_CARD_DARK_SX,
+                transition: "transform 120ms ease, box-shadow 120ms ease",
                 "&:hover": {
-                  boxShadow: 4,
+                  transform: "translate(-2px, -2px)",
+                  boxShadow: nbShadow(10, ACCENT),
                 },
               }}
             >
@@ -118,7 +129,7 @@ export default function RentalGrid() {
                   variant="body2"
                   sx={{
                     fontSize: "12px",
-                    color: "#E5C767",
+                    color: ACCENT,
                   }}
                   gutterBottom
                 >

--- a/app/components/SocialProofBar.tsx
+++ b/app/components/SocialProofBar.tsx
@@ -3,6 +3,7 @@
 import { useRef, useEffect, useState } from "react";
 import { Box, Typography } from "@mui/material";
 import { useInView } from "framer-motion";
+import { ACCENT, INK, PAPER, nbShadow } from "@/lib/theme";
 
 function AnimatedNumber({
   target,
@@ -41,7 +42,7 @@ function AnimatedNumber({
       sx={{
         fontSize: { xs: "28px", sm: "36px", md: "44px" },
         fontWeight: 800,
-        color: "white",
+        color: ACCENT,
         lineHeight: 1,
       }}
     >
@@ -83,10 +84,10 @@ export default function SocialProofBar() {
           textAlign: "center",
           py: { xs: 3, md: 4 },
           px: { xs: 2, md: 4 },
-          borderRadius: "16px",
-          border: "1px solid rgba(229,199,103,0.15)",
-          background:
-            "linear-gradient(135deg, rgba(229,199,103,0.04) 0%, rgba(0,0,0,0) 100%)",
+          borderRadius: 0,
+          border: `3px solid ${PAPER}`,
+          bgcolor: INK,
+          boxShadow: nbShadow(8, ACCENT),
         }}
       >
         {stats.map((stat) => (
@@ -101,7 +102,7 @@ export default function SocialProofBar() {
               sx={{
                 mt: 0.5,
                 fontSize: { xs: "11px", sm: "13px" },
-                color: "rgba(255,255,255,0.6)",
+                color: PAPER,
                 letterSpacing: "0.08em",
                 fontWeight: 600,
                 textTransform: "uppercase",
@@ -118,7 +119,7 @@ export default function SocialProofBar() {
           mt: 2.5,
           textAlign: "center",
           fontSize: { xs: "12px", sm: "14px" },
-          color: "rgba(255,255,255,0.5)",
+          color: "rgba(243,237,226,0.7)",
           letterSpacing: "0.06em",
         }}
       >

--- a/app/components/TrustWall.tsx
+++ b/app/components/TrustWall.tsx
@@ -2,6 +2,7 @@
 
 import { Box, Typography } from "@mui/material";
 import Image from "next/image";
+import { ACCENT, PAPER } from "@/lib/theme";
 
 const S3 = "https://dripdome-site.s3.us-east-2.amazonaws.com/nu_logo";
 
@@ -40,10 +41,6 @@ function LogoMarquee() {
       sx={{
         overflow: "hidden",
         width: "100%",
-        maskImage:
-          "linear-gradient(to right, transparent 0%, black 10%, black 90%, transparent 100%)",
-        WebkitMaskImage:
-          "linear-gradient(to right, transparent 0%, black 10%, black 90%, transparent 100%)",
       }}
     >
       <Box
@@ -65,9 +62,6 @@ function LogoMarquee() {
               display: "flex",
               alignItems: "center",
               justifyContent: "center",
-              opacity: 0.7,
-              transition: "opacity 0.3s",
-              "&:hover": { opacity: 1 },
             }}
           >
             <Image
@@ -96,15 +90,18 @@ export function TrustPress() {
     >
       <Box sx={{ maxWidth: 900, mx: "auto" }}>
         <Typography
+          variant="h2"
           sx={{
             fontSize: { xs: "24px", sm: "40px", lg: "50px" },
-            fontWeight: "bold",
             color: "white",
             textAlign: "center",
             mb: { xs: 2, md: 3 },
           }}
         >
-          In the Press
+          In the{" "}
+          <Box component="span" sx={{ color: ACCENT }}>
+            Press
+          </Box>
         </Typography>
         <Box
           sx={{
@@ -122,18 +119,14 @@ export function TrustPress() {
               target="_blank"
               rel="noopener noreferrer"
               sx={{
-                color: "rgba(255,255,255,0.6)",
+                color: PAPER,
                 fontSize: { xs: "14px", sm: "16px", md: "18px" },
                 textDecoration: "none",
                 letterSpacing: "0.04em",
-                transition: "color 0.2s",
-                "&:hover": { color: "#E5C767" },
+                "&:hover": { color: ACCENT, "& span": { color: ACCENT } },
               }}
             >
-              <Box
-                component="span"
-                sx={{ fontWeight: 700, color: "rgba(255,255,255,0.85)" }}
-              >
+              <Box component="span" sx={{ fontWeight: 700, color: "white" }}>
                 {item.outlet}
               </Box>
               {" — "}
@@ -160,13 +153,15 @@ export default function TrustWall() {
         variant="h2"
         sx={{
           fontSize: { xs: "24px", sm: "40px", lg: "50px" },
-          fontWeight: "bold",
           color: "white",
           textAlign: "center",
           mb: { xs: 3, md: 5 },
         }}
       >
-        Trusted By
+        Trusted{" "}
+        <Box component="span" sx={{ color: ACCENT }}>
+          By
+        </Box>
       </Typography>
 
       <LogoMarquee />

--- a/app/components/WorkReel.tsx
+++ b/app/components/WorkReel.tsx
@@ -2,6 +2,7 @@
 
 import { Box } from "@mui/material";
 import Image from "next/image";
+import { INK, PAPER } from "@/lib/theme";
 
 const S3 = "https://dripdome-site.s3.us-east-2.amazonaws.com";
 
@@ -64,7 +65,8 @@ function MarqueeRow({
               width: { xs: 200, sm: 280, md: 320 },
               height: { xs: 140, sm: 190, md: 220 },
               flexShrink: 0,
-              borderRadius: "12px",
+              border: `2px solid ${PAPER}`,
+              borderRadius: 0,
               overflow: "hidden",
             }}
           >
@@ -90,6 +92,7 @@ export default function WorkReel() {
       sx={{
         width: "100%",
         overflow: "hidden",
+        bgcolor: INK,
         py: { xs: 2, md: 4 },
         display: "flex",
         flexDirection: "column",

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,29 +3,32 @@
 @tailwind utilities;
 
 .page-container {
-  background-color: black;
+  background-color: #111111;
   width: auto;
   height: 100vh;
 }
 
-/* Change bullet color, size, margin, etc. */
+/* Neobrutalist swiper bullets: hard squares, ink borders, gold active. */
 .swiper-pagination-bullet {
-  background-color: white !important; /* Change the bullet color */
-  width: 12px; /* Adjust bullet size */
-  height: 12px;
-  margin: 12px 6px; /* Add horizontal spacing */
+  background-color: #f3ede2 !important;
+  border: 2px solid #111111 !important;
+  border-radius: 0 !important;
+  width: 14px;
+  height: 14px;
+  margin: 12px 6px;
   opacity: 1;
 }
 
 .swiper-pagination-bullet-active {
-  background-color: #E5C767 !important;
-  border: 2px solid black !important; /* Active bullet color */
+  background-color: #c0c0c0 !important;
+  border: 2px solid #111111 !important;
+  box-shadow: 2px 2px 0 0 #111111;
   opacity: 1;
 }
 
 /* Adjust pagination container padding/margin */
 .swiper-pagination {
-  bottom: 20px !important; /* Move pagination up or down */
+  bottom: 20px !important;
   padding: 10px;
 }
 
@@ -36,58 +39,59 @@
 }
 
 :root {
-  --background: 0 0% 100%;
-  --foreground: 0 0% 3.9%;
+  --background: 40 33% 92%;
+  --foreground: 0 0% 7%;
   --card: 0 0% 100%;
-  --card-foreground: 0 0% 3.9%;
+  --card-foreground: 0 0% 7%;
   --popover: 0 0% 100%;
-  --popover-foreground: 0 0% 3.9%;
-  --primary: 0 0% 9%;
-  --primary-foreground: 0 0% 98%;
-  --secondary: 0 0% 96.1%;
-  --secondary-foreground: 0 0% 9%;
-  --muted: 0 0% 96.1%;
-  --muted-foreground: 0 0% 45.1%;
-  --accent: 0 0% 96.1%;
-  --accent-foreground: 0 0% 9%;
-  --destructive: 0 84.2% 60.2%;
-  --destructive-foreground: 0 0% 98%;
-  --border: 0 0% 89.8%;
-  --input: 0 0% 89.8%;
-  --ring: 0 0% 3.9%;
-  --chart-1: 12 76% 61%;
-  --chart-2: 173 58% 39%;
-  --chart-3: 197 37% 24%;
-  --chart-4: 43 74% 66%;
-  --chart-5: 27 87% 67%;
-  --radius: 0.5rem;
+  --popover-foreground: 0 0% 7%;
+  --primary: 0 0% 7%;
+  --primary-foreground: 40 33% 92%;
+  --secondary: 175 53% 68%;
+  --secondary-foreground: 0 0% 7%;
+  --muted: 40 20% 85%;
+  --muted-foreground: 0 0% 25%;
+  --accent: 175 53% 68%;
+  --accent-foreground: 0 0% 7%;
+  --destructive: 22 100% 50%;
+  --destructive-foreground: 0 0% 7%;
+  --border: 0 0% 7%;
+  --input: 0 0% 7%;
+  --ring: 175 53% 68%;
+  --chart-1: 175 53% 68%;
+  --chart-2: 22 100% 50%;
+  --chart-3: 0 0% 7%;
+  --chart-4: 40 33% 92%;
+  --chart-5: 0 0% 25%;
+  --radius: 0rem;
 }
 
 .dark {
-  --background: 0 0% 3.9%;
-  --foreground: 0 0% 98%;
-  --card: 0 0% 3.9%;
-  --card-foreground: 0 0% 98%;
-  --popover: 0 0% 3.9%;
-  --popover-foreground: 0 0% 98%;
-  --primary: 0 0% 98%;
-  --primary-foreground: 0 0% 9%;
-  --secondary: 0 0% 14.9%;
-  --secondary-foreground: 0 0% 98%;
-  --muted: 0 0% 14.9%;
-  --muted-foreground: 0 0% 63.9%;
-  --accent: 0 0% 14.9%;
-  --accent-foreground: 0 0% 98%;
-  --destructive: 0 62.8% 30.6%;
-  --destructive-foreground: 0 0% 98%;
-  --border: 0 0% 14.9%;
-  --input: 0 0% 14.9%;
-  --ring: 0 0% 83.1%;
-  --chart-1: 220 70% 50%;
-  --chart-2: 160 60% 45%;
-  --chart-3: 30 80% 55%;
-  --chart-4: 280 65% 60%;
-  --chart-5: 340 75% 55%;
+  --background: 0 0% 7%;
+  --foreground: 40 33% 92%;
+  --card: 0 0% 7%;
+  --card-foreground: 40 33% 92%;
+  --popover: 0 0% 7%;
+  --popover-foreground: 40 33% 92%;
+  --primary: 40 33% 92%;
+  --primary-foreground: 0 0% 7%;
+  --secondary: 175 53% 68%;
+  --secondary-foreground: 0 0% 7%;
+  --muted: 0 0% 15%;
+  --muted-foreground: 40 20% 70%;
+  --accent: 175 53% 68%;
+  --accent-foreground: 0 0% 7%;
+  --destructive: 22 100% 50%;
+  --destructive-foreground: 0 0% 7%;
+  --border: 40 33% 92%;
+  --input: 40 33% 92%;
+  --ring: 175 53% 68%;
+  --chart-1: 175 53% 68%;
+  --chart-2: 22 100% 50%;
+  --chart-3: 40 33% 92%;
+  --chart-4: 0 0% 25%;
+  --chart-5: 0 0% 60%;
+  --radius: 0rem;
 }
 
 * {
@@ -97,9 +101,15 @@
 
 html,
 body {
-  background: black;
+  background: #111111;
   padding: 0;
   margin: 0;
+}
+
+/* Neobrutalism: metallic silver text selection, no soft edges anywhere. */
+::selection {
+  background: #c0c0c0;
+  color: #111111;
 }
 
 @layer base {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from "next";
-import { Source_Sans_3 } from "next/font/google";
+import { Archivo_Black, Space_Grotesk } from "next/font/google";
 import Script from "next/script";
 import "./globals.css";
 import ClientLayout from "./ClientLayout";
@@ -9,10 +9,17 @@ import ThemeRegistry from "./ThemeRegistry";
 
 const GTM_ID = process.env.NEXT_PUBLIC_GTM_ID;
 
-const sourceSans = Source_Sans_3({
+const archivoBlack = Archivo_Black({
+  weight: "400",
   subsets: ["latin"],
   display: "swap",
-  variable: "--font-source-sans",
+  variable: "--font-display",
+});
+
+const spaceGrotesk = Space_Grotesk({
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-body",
 });
 
 export const metadata: Metadata = {
@@ -69,7 +76,7 @@ export const metadata: Metadata = {
 export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
-  themeColor: "#ffffff",
+  themeColor: "#F3EDE2",
 };
 
 export default function RootLayout({
@@ -78,7 +85,10 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={sourceSans.variable}>
+    <html
+      lang="en"
+      className={`${archivoBlack.variable} ${spaceGrotesk.variable}`}
+    >
       <head>
         <Script
           id="google-ads-gtag"
@@ -99,7 +109,7 @@ gtag('config', 'AW-18099031816');`}
           </Script>
         )}
       </head>
-      <body className={sourceSans.className}>
+      <body className={spaceGrotesk.className}>
         {GTM_ID && (
           <noscript>
             <iframe

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 import { Box } from "@mui/material";
 import type { Metadata } from "next";
+import { INK } from "@/lib/theme";
 import HomeHero from "./components/HomeHero";
 import SocialProofBar from "./components/SocialProofBar";
 import HomeFeaturedWork from "./components/HomeFeaturedWork";
@@ -50,7 +51,7 @@ export const metadata: Metadata = {
 
 export default function Home() {
   return (
-    <Box component="main" sx={{ bgcolor: "black", color: "common.white" }}>
+    <Box component="main" sx={{ bgcolor: INK, color: "common.white" }}>
       <HomeHero />
       <SocialProofBar />
       <HomeFeaturedWork />

--- a/app/portfolio/PortfolioContent.tsx
+++ b/app/portfolio/PortfolioContent.tsx
@@ -6,7 +6,7 @@ import Contact from "../components/Contact";
 import { motion } from "framer-motion";
 import FeaturedProjects from "../components/FeaturedProjects";
 import PressSection from "../components/PressSection";
-import { BRAND_GRADIENT_TEXT_SX } from "@/lib/theme";
+import { ACCENT, INK } from "@/lib/theme";
 
 export default function PortfolioContent() {
   return (
@@ -14,7 +14,7 @@ export default function PortfolioContent() {
       sx={{
         minHeight: "100vh",
         width: "100%",
-        bgcolor: "black",
+        bgcolor: INK,
         px: 2,
         pt: { xs: 8, md: 6 },
         overflowX: "hidden",
@@ -32,7 +32,6 @@ export default function PortfolioContent() {
             color="white"
             sx={{
               fontSize: { xs: "45px", sm: "95px", lg: "96px" },
-              fontWeight: "bold",
               marginBottom: { xs: "20px", md: "30px" },
               textAlign: "center",
             }}
@@ -76,7 +75,6 @@ export default function PortfolioContent() {
                 color="white"
                 sx={{
                   fontSize: { xs: "30px", sm: "55px", lg: "70px" },
-                  fontWeight: "bold",
                   display: "inline",
                 }}
               >
@@ -87,8 +85,7 @@ export default function PortfolioContent() {
                 component="span"
                 sx={{
                   fontSize: { xs: "30px", sm: "55px", lg: "70px" },
-                  fontWeight: "bold",
-                  ...BRAND_GRADIENT_TEXT_SX,
+                  color: ACCENT,
                 }}
               >
                 PROJECTS
@@ -119,7 +116,7 @@ export default function PortfolioContent() {
             mt: 8,
             py: 12,
             px: { xs: 2, md: 8 },
-            bgcolor: "black",
+            bgcolor: INK,
             color: "white",
           }}
         >

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from "next";
 import { Box, Container, Typography } from "@mui/material";
+import { INK, PAPER } from "@/lib/theme";
 
 export const metadata: Metadata = {
   title: "Privacy Policy | DripDome",
@@ -34,7 +35,7 @@ export default function PrivacyPolicy() {
     <Box
       component="main"
       sx={{
-        bgcolor: "black",
+        bgcolor: PAPER,
         minHeight: "100vh",
         pt: { xs: 12, md: 16 },
         pb: 8,
@@ -44,10 +45,9 @@ export default function PrivacyPolicy() {
         <Typography
           variant="h1"
           component="h1"
-          color="white"
           sx={{
             fontSize: { xs: "36px", sm: "48px", md: "56px" },
-            fontWeight: "bold",
+            color: INK,
             mb: 4,
             textAlign: "center",
           }}
@@ -55,7 +55,7 @@ export default function PrivacyPolicy() {
           Privacy Policy
         </Typography>
 
-        <Box sx={{ color: "grey.300", "& > p": { mb: 3 } }}>
+        <Box sx={{ color: "rgba(17,17,17,0.85)", "& > p": { mb: 3 } }}>
           <Typography variant="body1" component="p">
             Your privacy is important to us. It is our policy to respect your
             privacy regarding any information we may collect from you across our

--- a/app/rentals/RentalForm.tsx
+++ b/app/rentals/RentalForm.tsx
@@ -15,6 +15,14 @@ import {
 import { useState } from "react";
 import ReCAPTCHA from "react-google-recaptcha";
 import { rentalEquipment } from "./data";
+import {
+  ACCENT,
+  INK,
+  NB_BORDER,
+  NB_BUTTON_SX,
+  SURFACE,
+  nbShadow,
+} from "@/lib/theme";
 
 export default function RentalForm() {
   const recaptchaRef = useRef<ReCAPTCHA>(null);
@@ -26,16 +34,30 @@ export default function RentalForm() {
   };
 
   const inputStyles = {
-    "& .MuiInputBase-root": { bgcolor: "white", color: "black" },
+    "& .MuiOutlinedInput-root": {
+      bgcolor: SURFACE,
+      color: INK,
+      borderRadius: 0,
+      transition: "box-shadow 120ms ease",
+      "& fieldset": { border: NB_BORDER },
+      "&:hover fieldset": { border: NB_BORDER },
+      "&.Mui-focused fieldset": { border: `3px solid ${ACCENT}` },
+      "&.Mui-focused": { boxShadow: nbShadow(4) },
+    },
     "& .MuiInputBase-input::placeholder": {
-      color: "rgba(0,0,0,0.7)",
+      color: "rgba(17,17,17,0.6)",
       opacity: 1,
     },
+    // Resting labels sit inside the white input; shrunk labels float over
+    // the dark page background, so they flip to light.
     "& .MuiInputLabel-root": {
-      color: "rgba(0,0,0,0.7)",
+      color: "rgba(17,17,17,0.7)",
     },
-    "& .MuiOutlinedInput-notchedOutline": {
-      borderColor: "rgba(0,0,0,0.23)",
+    "& .MuiInputLabel-root.MuiInputLabel-shrink": {
+      color: "rgba(243,237,226,0.85)",
+    },
+    "& .MuiInputLabel-root.Mui-focused": {
+      color: ACCENT,
     },
   };
 
@@ -54,7 +76,6 @@ export default function RentalForm() {
         component="h2"
         sx={{
           fontSize: { xs: "40px", md: "60px", lg: "70px" },
-          fontWeight: "bold",
           marginBottom: "15px",
           justifyContent: "center",
           display: "flex",
@@ -177,15 +198,7 @@ export default function RentalForm() {
         />
 
         {/* Equipment Desired - Dropdown */}
-        <FormControl
-          fullWidth
-          sx={{
-            "& .MuiInputBase-root": { bgcolor: "white", color: "black" },
-            "& .MuiInputLabel-root": { color: "rgba(0,0,0,0.7)" },
-            "& .MuiInputLabel-root.Mui-focused": { color: "black" },
-            "& .MuiSelect-select": { color: "black" },
-          }}
-        >
+        <FormControl fullWidth sx={inputStyles}>
           <InputLabel id="equipment-label">EQUIPMENT DESIRED</InputLabel>
           <Select
             labelId="equipment-label"
@@ -252,15 +265,14 @@ export default function RentalForm() {
         <Button
           type="submit"
           variant="contained"
+          disableElevation
           sx={{
             alignSelf: "center",
             px: 4,
             py: 1.5,
             width: "80dvw",
             maxWidth: 900,
-            fontWeight: 700,
-            bgcolor: "#16a34a",
-            "&:hover": { bgcolor: "#1d4ed8" },
+            ...NB_BUTTON_SX,
           }}
         >
           SUBMIT RENTAL REQUEST

--- a/app/rentals/page.tsx
+++ b/app/rentals/page.tsx
@@ -3,6 +3,7 @@ import { Box, Typography } from "@mui/material";
 import RentalGrid from "../components/RentalGrid";
 import RentalForm from "./RentalForm";
 import Footer from "../ui/Footer";
+import { INK } from "@/lib/theme";
 
 export const metadata: Metadata = {
   title: "Rentals | DripDome - Props & Set Piece Rentals NYC",
@@ -42,15 +43,14 @@ export const metadata: Metadata = {
 export default function RentalsPage() {
   return (
     <>
-      <Box sx={{ backgroundColor: "black" }}>
-        <Box sx={{ backgroundColor: "black" }}>
+      <Box sx={{ backgroundColor: INK }}>
+        <Box sx={{ backgroundColor: INK }}>
           <Typography
             variant="h1"
             component="h1"
             color="white"
             sx={{
               fontSize: { xs: "55px", sm: "95px", lg: "150px" },
-              fontWeight: "bold",
               paddingTop: { xs: 4, md: 8 },
               paddingLeft: "10px",
               paddingRight: "10px",
@@ -61,14 +61,13 @@ export default function RentalsPage() {
           </Typography>
 
           {/* Equipment Grid */}
-          <Box sx={{ backgroundColor: "black", py: 4, px: { xs: 0, md: 8 } }}>
+          <Box sx={{ backgroundColor: INK, py: 4, px: { xs: 0, md: 8 } }}>
             <Typography
               variant="h2"
               component="h2"
               color="white"
               sx={{
                 fontSize: { xs: "30px", sm: "45px", lg: "50px" },
-                fontWeight: "bold",
                 marginBottom: { xs: "20px", md: "30px" },
                 textAlign: "center",
               }}
@@ -79,7 +78,7 @@ export default function RentalsPage() {
           </Box>
 
           {/* Rental Request Form */}
-          <Box sx={{ backgroundColor: "black", py: 4 }}>
+          <Box sx={{ backgroundColor: INK, py: 4 }}>
             <RentalForm />
           </Box>
         </Box>

--- a/app/services/ServicesContent.tsx
+++ b/app/services/ServicesContent.tsx
@@ -5,7 +5,15 @@ import { Box, Typography, Collapse, IconButton } from "@mui/material";
 import { motion } from "framer-motion";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import Contact from "../components/Contact";
-import { BRAND_GRADIENT_TEXT_SX } from "@/lib/theme";
+import {
+  ACCENT,
+  INK,
+  NB_BORDER,
+  NB_BORDER_THIN,
+  PAPER,
+  SURFACE,
+  nbShadow,
+} from "@/lib/theme";
 
 const services = [
   {
@@ -173,19 +181,18 @@ function ServiceCard({
           cursor: "pointer",
           position: "relative",
           p: { xs: 2.5, md: 3.5 },
-          borderRadius: 3,
-          bgcolor: "rgba(255,255,255,0.03)",
-          border: "1px solid",
-          borderColor: isExpanded
-            ? "rgba(229,199,103,0.5)"
-            : "rgba(255,255,255,0.1)",
-          transition: "all 0.3s ease",
+          borderRadius: 0,
+          bgcolor: SURFACE,
+          border: NB_BORDER,
+          boxShadow: isExpanded ? nbShadow(6) : nbShadow(4),
+          transition: "transform 120ms ease, box-shadow 120ms ease",
           "&:hover": {
-            bgcolor: "rgba(255,255,255,0.06)",
-            borderColor: isExpanded
-              ? "rgba(229,199,103,0.7)"
-              : "rgba(255,255,255,0.2)",
-            transform: "translateY(-2px)",
+            transform: "translate(-2px, -2px)",
+            boxShadow: nbShadow(6),
+          },
+          "&:active": {
+            transform: "translate(2px, 2px)",
+            boxShadow: nbShadow(0),
           },
         }}
       >
@@ -199,22 +206,25 @@ function ServiceCard({
         >
           <Box sx={{ flex: 1 }}>
             <Box sx={{ display: "flex", alignItems: "center", gap: 2, mb: 1 }}>
-              <Typography
+              <Box
                 sx={{
+                  px: 1,
+                  py: 0.25,
+                  bgcolor: ACCENT,
+                  border: NB_BORDER_THIN,
                   fontSize: { xs: "12px", md: "14px" },
                   fontWeight: 700,
-                  color: "#E5C767",
+                  color: INK,
                   letterSpacing: "0.1em",
                 }}
               >
                 {service.number}
-              </Typography>
+              </Box>
               <Typography
                 variant="h3"
                 sx={{
                   fontSize: { xs: "18px", sm: "22px", md: "26px" },
-                  fontWeight: 700,
-                  color: "white",
+                  color: INK,
                   lineHeight: 1.2,
                 }}
               >
@@ -224,7 +234,7 @@ function ServiceCard({
             <Typography
               sx={{
                 fontSize: { xs: "14px", md: "16px" },
-                color: "rgba(255,255,255,0.7)",
+                color: "rgba(17,17,17,0.75)",
                 lineHeight: 1.6,
               }}
             >
@@ -234,10 +244,13 @@ function ServiceCard({
           <IconButton
             size="small"
             sx={{
-              color: "rgba(255,255,255,0.5)",
+              color: INK,
+              borderRadius: 0,
+              border: NB_BORDER_THIN,
+              bgcolor: isExpanded ? ACCENT : SURFACE,
               transform: isExpanded ? "rotate(180deg)" : "rotate(0deg)",
               transition: "transform 0.3s ease",
-              "&:hover": { bgcolor: "rgba(255,255,255,0.1)" },
+              "&:hover": { bgcolor: ACCENT },
             }}
           >
             <ExpandMoreIcon />
@@ -249,7 +262,7 @@ function ServiceCard({
             sx={{
               mt: 2.5,
               pt: 2.5,
-              borderTop: "1px solid rgba(255,255,255,0.1)",
+              borderTop: NB_BORDER_THIN,
             }}
           >
             <Box
@@ -267,11 +280,11 @@ function ServiceCard({
                   component="li"
                   key={idx}
                   sx={{
-                    color: "rgba(255,255,255,0.85)",
+                    color: "rgba(17,17,17,0.85)",
                     fontSize: { xs: "13px", md: "15px" },
                     lineHeight: 1.6,
                     "&::marker": {
-                      color: "#E5C767",
+                      color: ACCENT,
                     },
                   }}
                 >
@@ -294,7 +307,7 @@ export default function ServicesContent() {
   };
 
   return (
-    <Box sx={{ bgcolor: "black", overflow: "hidden", minHeight: "100vh" }}>
+    <Box sx={{ bgcolor: INK, overflow: "hidden", minHeight: "100vh" }}>
       {/* Hero Section */}
       <Box
         sx={{
@@ -314,7 +327,6 @@ export default function ServicesContent() {
             variant="h1"
             sx={{
               fontSize: { xs: "42px", sm: "64px", md: "80px", lg: "96px" },
-              fontWeight: 800,
               color: "white",
               textAlign: "center",
               mb: { xs: 3, md: 4 },
@@ -324,7 +336,14 @@ export default function ServicesContent() {
             WHAT WE{" "}
             <Box
               component="span"
-              sx={{ display: "inline", ...BRAND_GRADIENT_TEXT_SX }}
+              sx={{
+                display: "inline-block",
+                bgcolor: ACCENT,
+                color: INK,
+                px: { xs: 1.5, md: 2.5 },
+                boxShadow: nbShadow(8),
+                transform: "rotate(-1.5deg)",
+              }}
             >
               DO
             </Box>
@@ -348,7 +367,7 @@ export default function ServicesContent() {
             }}
           >
             At{" "}
-            <Box component="span" sx={{ color: "#E5C767", fontWeight: 600 }}>
+            <Box component="span" sx={{ color: ACCENT, fontWeight: 700 }}>
               Drip Dome Productions
             </Box>
             , we bring ideas to life through design, fabrication, and
@@ -359,132 +378,131 @@ export default function ServicesContent() {
         </motion.div>
       </Box>
 
-      {/* Core Services Header */}
-      <Box sx={{ maxWidth: "1200px", mx: "auto", px: { xs: 2, md: 6 } }}>
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.3, duration: 0.6 }}
-        >
-          <Box
-            sx={{
-              display: "flex",
-              alignItems: "center",
-              gap: 2,
-              mb: { xs: 3, md: 4 },
-            }}
+      {/* Services Section (paper) */}
+      <Box
+        sx={{
+          bgcolor: PAPER,
+          borderTop: `4px solid ${ACCENT}`,
+          borderBottom: `4px solid ${ACCENT}`,
+          py: { xs: 5, md: 8 },
+        }}
+      >
+        {/* Core Services Header */}
+        <Box sx={{ maxWidth: "1200px", mx: "auto", px: { xs: 2, md: 6 } }}>
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.3, duration: 0.6 }}
           >
             <Box
               sx={{
-                height: "2px",
-                flex: 1,
-                background:
-                  "linear-gradient(90deg, transparent, rgba(229,199,103,0.5))",
-              }}
-            />
-            <Typography
-              sx={{
-                fontSize: { xs: "12px", md: "14px" },
-                fontWeight: 700,
-                color: "#E5C767",
-                letterSpacing: "0.2em",
-                textTransform: "uppercase",
+                display: "flex",
+                alignItems: "center",
+                gap: 2,
+                mb: { xs: 3, md: 4 },
               }}
             >
-              Our Core Services
-            </Typography>
-            <Box
-              sx={{
-                height: "2px",
-                flex: 1,
-                background:
-                  "linear-gradient(90deg, rgba(229,199,103,0.5), transparent)",
-              }}
-            />
-          </Box>
-        </motion.div>
-      </Box>
+              <Box sx={{ height: "3px", flex: 1, bgcolor: INK }} />
+              <Typography
+                sx={{
+                  fontSize: { xs: "12px", md: "14px" },
+                  fontWeight: 700,
+                  color: INK,
+                  letterSpacing: "0.2em",
+                  textTransform: "uppercase",
+                }}
+              >
+                Our Core Services
+              </Typography>
+              <Box sx={{ height: "3px", flex: 1, bgcolor: INK }} />
+            </Box>
+          </motion.div>
+        </Box>
 
-      {/* Services Grid */}
-      <Box
-        sx={{
-          maxWidth: "1200px",
-          mx: "auto",
-          px: { xs: 2, md: 6 },
-          pb: { xs: 6, md: 10 },
-        }}
-      >
+        {/* Services Grid */}
         <Box
           sx={{
-            display: "grid",
-            gridTemplateColumns: { xs: "1fr", lg: "1fr 1fr" },
-            gap: { xs: 2, md: 3 },
+            maxWidth: "1200px",
+            mx: "auto",
+            px: { xs: 2, md: 6 },
+            pb: { xs: 6, md: 10 },
           }}
         >
-          {services.map((service, index) => (
-            <ServiceCard
-              key={service.number}
-              service={service}
-              index={index}
-              isExpanded={expandedIndex === index}
-              onToggle={() => handleToggle(index)}
-            />
-          ))}
+          <Box
+            sx={{
+              display: "grid",
+              gridTemplateColumns: { xs: "1fr", lg: "1fr 1fr" },
+              gap: { xs: 2, md: 3 },
+            }}
+          >
+            {services.map((service, index) => (
+              <ServiceCard
+                key={service.number}
+                service={service}
+                index={index}
+                isExpanded={expandedIndex === index}
+                onToggle={() => handleToggle(index)}
+              />
+            ))}
+          </Box>
+        </Box>
+
+        {/* CTA Section */}
+        <Box
+          sx={{
+            maxWidth: "1200px",
+            mx: "auto",
+            px: { xs: 2, md: 6 },
+          }}
+        >
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.5, duration: 0.6 }}
+          >
+            <Box
+              sx={{
+                p: { xs: 4, md: 6 },
+                borderRadius: 0,
+                bgcolor: INK,
+                border: NB_BORDER,
+                boxShadow: nbShadow(8, ACCENT),
+                textAlign: "center",
+              }}
+            >
+              <Typography
+                variant="h2"
+                sx={{
+                  fontSize: { xs: "24px", sm: "32px", md: "40px" },
+                  color: "white",
+                  mb: 2,
+                }}
+              >
+                Ready to Build Something Amazing?
+              </Typography>
+              <Typography
+                sx={{
+                  fontSize: { xs: "14px", md: "18px" },
+                  color: "rgba(255,255,255,0.8)",
+                  maxWidth: "600px",
+                  mx: "auto",
+                }}
+              >
+                From the first spark of an idea to the final reveal, we handle
+                every detail. Let&apos;s create something unforgettable
+                together.
+              </Typography>
+            </Box>
+          </motion.div>
         </Box>
       </Box>
 
-      {/* CTA Section */}
-      <Box
-        sx={{
-          maxWidth: "1200px",
-          mx: "auto",
-          px: { xs: 2, md: 6 },
-          pb: { xs: 6, md: 10 },
-        }}
-      >
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.5, duration: 0.6 }}
-        >
-          <Box
-            sx={{
-              p: { xs: 4, md: 6 },
-              borderRadius: 4,
-              background:
-                "linear-gradient(135deg, rgba(229,199,103,0.1) 0%, rgba(59,130,246,0.1) 100%)",
-              border: "1px solid rgba(255,255,255,0.1)",
-              textAlign: "center",
-            }}
-          >
-            <Typography
-              variant="h2"
-              sx={{
-                fontSize: { xs: "24px", sm: "32px", md: "40px" },
-                fontWeight: 700,
-                color: "white",
-                mb: 2,
-              }}
-            >
-              Ready to Build Something Amazing?
-            </Typography>
-            <Typography
-              sx={{
-                fontSize: { xs: "14px", md: "18px" },
-                color: "rgba(255,255,255,0.7)",
-                maxWidth: "600px",
-                mx: "auto",
-              }}
-            >
-              From the first spark of an idea to the final reveal, we handle
-              every detail. Let&apos;s create something unforgettable together.
-            </Typography>
-          </Box>
-        </motion.div>
-      </Box>
-
       {/* Contact Section */}
-      <Box component="section" id="contact" sx={{ py: { xs: 6, md: 10 } }}>
+      <Box
+        component="section"
+        id="contact"
+        sx={{ bgcolor: INK, py: { xs: 6, md: 10 } }}
+      >
         <Contact />
       </Box>
     </Box>

--- a/app/styles/swiper-styles.css
+++ b/app/styles/swiper-styles.css
@@ -1,18 +1,20 @@
-/* Change the color of all pagination bullets */
+/* Neobrutalist pagination bullets: square, bordered, flat color */
 .swiper-pagination-bullet {
-  background: #007bff; /* Change to your desired color */
-  opacity: 0.5; /* Adjust the opacity for inactive bullets */
-  height: 8px;
-  width: 8px;
+  background: #f3ede2; /* PAPER */
+  opacity: 1;
+  height: 10px;
+  width: 10px;
+  border: 2px solid #111111; /* INK */
+  border-radius: 0;
 }
 
-/* Change the color and style of the active pagination bullet */
+/* Active bullet: flat metallic silver */
 .swiper-pagination-bullet-active {
-  height: 8px;
-  width: 8px;
-  background: #dead32;
-  border: 1px solid black; /* Change to your desired color */
-  opacity: 1; /* Ensure the active bullet is fully opaque */
+  height: 10px;
+  width: 10px;
+  background: #c0c0c0; /* ACCENT */
+  border: 2px solid #111111; /* INK */
+  opacity: 1;
 }
 
 .swiper-pagination {

--- a/app/theme.ts
+++ b/app/theme.ts
@@ -1,55 +1,103 @@
 // theme.ts
 import { createTheme } from '@mui/material/styles';
+import { ACCENT, INK, PAPER } from '@/lib/theme';
 
 /**
- * App colors (ONLY 3).
- * Replace these with your real brand values.
+ * Neobrutalist app colors.
  */
 export const APP_COLORS = {
   /** Used for page backgrounds and surfaces */
-  surface: "#FFFFFF",
+  surface: PAPER,
   /** Used for all text/icons */
-  ink: "#111111",
+  ink: INK,
   /** Used for buttons/links/highlights */
-  accent: "#E5C767",
+  accent: ACCENT,
 } as const;
 
 const FONT_FALLBACK =
   "system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif";
 
-const theme = createTheme({
-  typography: {
-    // Loaded in app/layout.tsx via Google Fonts <link> tags
-    fontFamily: `'Source Sans 3', ${FONT_FALLBACK}`,
+// Loaded in app/layout.tsx via next/font (Archivo Black + Space Grotesk)
+const DISPLAY_FONT = `var(--font-display), ${FONT_FALLBACK}`;
+const BODY_FONT = `var(--font-body), ${FONT_FALLBACK}`;
 
-    // Titles (h1-h6)
-    h1: { fontFamily: `'Zalando Sans Expanded', ${FONT_FALLBACK}` },
-    h2: { fontFamily: `'Zalando Sans Expanded', ${FONT_FALLBACK}` },
-    h3: { fontFamily: `'Zalando Sans Expanded', ${FONT_FALLBACK}` },
-    h4: { fontFamily: `'Zalando Sans Expanded', ${FONT_FALLBACK}` },
-    h5: { fontFamily: `'Zalando Sans Expanded', ${FONT_FALLBACK}` },
-    h6: { fontFamily: `'Zalando Sans Expanded', ${FONT_FALLBACK}` },
+const theme = createTheme({
+  shape: {
+    // Neobrutalism: no rounded corners, anywhere.
+    borderRadius: 0,
+  },
+  typography: {
+    fontFamily: BODY_FONT,
+
+    // Titles (h1-h6). Archivo Black ships a single 400 weight; explicit
+    // bold would only faux-bold it, so headings pin weight to 400.
+    h1: { fontFamily: DISPLAY_FONT, fontWeight: 400, textTransform: 'uppercase' },
+    h2: { fontFamily: DISPLAY_FONT, fontWeight: 400, textTransform: 'uppercase' },
+    h3: { fontFamily: DISPLAY_FONT, fontWeight: 400, textTransform: 'uppercase' },
+    h4: { fontFamily: DISPLAY_FONT, fontWeight: 400, textTransform: 'uppercase' },
+    h5: { fontFamily: DISPLAY_FONT, fontWeight: 400 },
+    h6: { fontFamily: DISPLAY_FONT, fontWeight: 400 },
 
     // Subheaders + paragraphs
-    subtitle1: { fontFamily: `'Source Sans 3', ${FONT_FALLBACK}` },
-    subtitle2: { fontFamily: `'Source Sans 3', ${FONT_FALLBACK}` },
-    body1: { fontFamily: `'Source Sans 3', ${FONT_FALLBACK}` },
-    body2: { fontFamily: `'Source Sans 3', ${FONT_FALLBACK}` },
+    subtitle1: { fontFamily: BODY_FONT },
+    subtitle2: { fontFamily: BODY_FONT },
+    body1: { fontFamily: BODY_FONT },
+    body2: { fontFamily: BODY_FONT },
+    button: { fontFamily: BODY_FONT, fontWeight: 700, letterSpacing: '0.04em' },
   },
   palette: {
     primary: {
-      main: '#FCF5EC', // mainBrown
+      main: INK,
     },
     secondary: {
-      main: '#DD9F28', // mainGold
+      main: ACCENT,
     },
-
     background: {
-      default: '#FCF5EC', // mainWhite
+      default: PAPER,
+      paper: PAPER,
     },
     text: {
-      primary: '#391E0C', // mainBrown
-      secondary: '#DD9F28', // mainGold
+      primary: INK,
+      secondary: '#3D3A33',
+    },
+  },
+  components: {
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          borderRadius: 0,
+        },
+      },
+    },
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          borderRadius: 0,
+        },
+      },
+    },
+    MuiOutlinedInput: {
+      styleOverrides: {
+        root: {
+          borderRadius: 0,
+        },
+      },
+    },
+    MuiChip: {
+      styleOverrides: {
+        root: {
+          borderRadius: 0,
+        },
+      },
+    },
+    MuiAccordion: {
+      styleOverrides: {
+        root: {
+          borderRadius: 0,
+          '&:first-of-type': { borderRadius: 0 },
+          '&:last-of-type': { borderRadius: 0 },
+        },
+      },
     },
   },
 });

--- a/app/ui/Footer.tsx
+++ b/app/ui/Footer.tsx
@@ -4,10 +4,14 @@ import React from "react";
 import Link from "next/link";
 import InstagramIcon from "@mui/icons-material/Instagram";
 import { Box, Container, IconButton, Typography } from "@mui/material";
+import { ACCENT, INK, PAPER, nbShadow } from "@/lib/theme";
 
 export default function Footer() {
   return (
-    <Box component="footer" sx={{ bgcolor: "black", py: 2 }}>
+    <Box
+      component="footer"
+      sx={{ bgcolor: INK, py: 2.5, borderTop: `4px solid ${ACCENT}` }}
+    >
       <Container maxWidth="lg" sx={{ px: { xs: 2, md: 4 } }}>
         <Box
           sx={{
@@ -24,11 +28,19 @@ export default function Footer() {
             rel="noopener noreferrer"
             aria-label="DripDome Instagram"
             sx={{
-              bgcolor: "rgba(0,0,0,0.6)",
-              borderRadius: 2,
+              bgcolor: INK,
+              borderRadius: 0,
+              border: `2px solid ${PAPER}`,
+              boxShadow: nbShadow(3, ACCENT),
               p: 1,
               color: "common.white",
-              "&:hover": { bgcolor: "rgba(0,0,0,0.75)", color: "#E5C767" },
+              transition: "transform 120ms ease, box-shadow 120ms ease",
+              "&:hover": {
+                bgcolor: ACCENT,
+                color: INK,
+                transform: "translate(-2px, -2px)",
+                boxShadow: nbShadow(5, PAPER),
+              },
             }}
           >
             <InstagramIcon sx={{ width: 28, height: 28 }} />
@@ -38,10 +50,14 @@ export default function Footer() {
             component={Link}
             href="/privacy"
             sx={{
-              color: "grey.500",
+              color: PAPER,
               textDecoration: "none",
               fontSize: 14,
-              "&:hover": { color: "grey.300" },
+              fontWeight: 700,
+              textTransform: "uppercase",
+              letterSpacing: "0.06em",
+              borderBottom: "2px solid transparent",
+              "&:hover": { color: ACCENT, borderBottom: `2px solid ${ACCENT}` },
             }}
           >
             Privacy Policy

--- a/app/ui/Navbar.tsx
+++ b/app/ui/Navbar.tsx
@@ -19,6 +19,7 @@ import {
   ListItemText,
   Toolbar,
 } from "@mui/material";
+import { ACCENT, INK, PAPER, nbShadow } from "@/lib/theme";
 
 export default function Navbar() {
   const pathname = usePathname();
@@ -43,9 +44,8 @@ export default function Navbar() {
         position="fixed"
         elevation={0}
         sx={{
-          bgcolor: isOverlay ? "rgba(0,0,0,0.25)" : "black",
-          backdropFilter: isOverlay ? "blur(10px)" : undefined,
-          WebkitBackdropFilter: isOverlay ? "blur(10px)" : undefined,
+          bgcolor: INK,
+          borderBottom: `4px solid ${ACCENT}`,
           left: 0,
           right: 0,
           width: "100%",
@@ -70,10 +70,11 @@ export default function Navbar() {
               sx={{
                 display: { md: "none" },
                 ml: 0.5,
-                borderRadius: 2,
+                borderRadius: 0,
+                border: `2px solid ${PAPER}`,
                 color: "common.white",
                 p: 1,
-                "&:hover": { bgcolor: "rgba(0,0,0,0.75)" },
+                "&:hover": { bgcolor: ACCENT, color: INK, borderColor: PAPER },
               }}
             >
               <HomeTwoToneIcon sx={{ width: 28, height: 28 }} />
@@ -106,7 +107,14 @@ export default function Navbar() {
             <IconButton
               aria-label="Open navigation menu"
               onClick={toggleMenu}
-              sx={{ display: { md: "none" }, mr: 1.5, color: "common.white" }}
+              sx={{
+                display: { md: "none" },
+                mr: 1.5,
+                color: "common.white",
+                borderRadius: 0,
+                border: `2px solid ${PAPER}`,
+                "&:hover": { bgcolor: ACCENT, color: INK },
+              }}
             >
               <MenuIcon sx={{ width: 32, height: 32 }} />
             </IconButton>
@@ -120,14 +128,22 @@ export default function Navbar() {
                     component={Link}
                     href={link.href}
                     sx={{
-                      color: "common.white",
-                      fontSize: 18,
-                      fontWeight: 600,
+                      color: isActive ? INK : "common.white",
+                      bgcolor: isActive ? ACCENT : "transparent",
+                      fontSize: 17,
+                      fontWeight: 700,
                       borderRadius: 0,
-                      borderBottom: isActive
-                        ? "2px solid #E5C767"
+                      px: 1.75,
+                      border: isActive
+                        ? `2px solid ${PAPER}`
                         : "2px solid transparent",
-                      "&:hover": { color: "#E5C767", bgcolor: "transparent" },
+                      boxShadow: isActive ? nbShadow(3, PAPER) : "none",
+                      "&:hover": {
+                        bgcolor: ACCENT,
+                        color: INK,
+                        border: `2px solid ${PAPER}`,
+                        boxShadow: nbShadow(3, PAPER),
+                      },
                     }}
                   >
                     {link.name}
@@ -145,7 +161,7 @@ export default function Navbar() {
         onClose={() => setIsOpen(false)}
         PaperProps={{
           sx: {
-            bgcolor: "black",
+            bgcolor: INK,
             color: "common.white",
             height: "100vh",
           },
@@ -164,15 +180,21 @@ export default function Navbar() {
         >
           <List sx={{ width: "100%", maxWidth: 420 }}>
             {links.map((link) => (
-              <ListItem key={link.name} disablePadding sx={{ my: 0.75 }}>
+              <ListItem key={link.name} disablePadding sx={{ my: 1.25 }}>
                 <ListItemButton
                   component={Link}
                   href={link.href}
                   onClick={() => setIsOpen(false)}
                   sx={{
-                    bgcolor: "rgba(0,0,0,0.7)",
-                    borderRadius: 2,
-                    "&:hover": { color: "#E5C767" },
+                    bgcolor: INK,
+                    borderRadius: 0,
+                    border: `3px solid ${PAPER}`,
+                    boxShadow: nbShadow(5, ACCENT),
+                    "&:hover": {
+                      bgcolor: ACCENT,
+                      color: INK,
+                      boxShadow: nbShadow(5, PAPER),
+                    },
                   }}
                 >
                   <ListItemText
@@ -180,7 +202,7 @@ export default function Navbar() {
                     primaryTypographyProps={{
                       align: "center",
                       fontSize: 22,
-                      fontWeight: 600,
+                      fontWeight: 700,
                     }}
                   />
                 </ListItemButton>

--- a/app/video-photo/page.tsx
+++ b/app/video-photo/page.tsx
@@ -7,6 +7,7 @@ import {
   Container,
   Typography,
 } from "@mui/material";
+import { ACCENT, INK, PAPER, nbShadow } from "@/lib/theme";
 
 export const metadata: Metadata = {
   title: "Video & Photo | DripDome - Set Design for Film & Photography NYC",
@@ -57,7 +58,7 @@ export default function VideoPhotoPage() {
     <Box
       component="section"
       id="work-gallery"
-      sx={{ py: 16, bgcolor: "grey.100" }}
+      sx={{ py: 16, bgcolor: INK }}
     >
       <Container maxWidth="lg" sx={{ px: { xs: 2, md: 4 } }}>
         <Typography
@@ -65,9 +66,8 @@ export default function VideoPhotoPage() {
           component="h2"
           sx={{
             textAlign: "center",
-            color: "grey.900",
+            color: PAPER,
             mb: 4,
-            fontWeight: 800,
           }}
         >
           Our Work
@@ -75,7 +75,7 @@ export default function VideoPhotoPage() {
         <Typography
           variant="body1"
           component="p"
-          sx={{ textAlign: "center", color: "grey.700", mb: 8 }}
+          sx={{ textAlign: "center", color: "rgba(243,237,226,0.8)", mb: 8 }}
         >
           Explore some of the amazing projects we&apos;ve worked on.
         </Typography>
@@ -98,10 +98,15 @@ export default function VideoPhotoPage() {
               sx={{
                 position: "relative",
                 overflow: "hidden",
-                borderRadius: 2,
-                boxShadow: 3,
-                "&:hover .MuiCardMedia-root": { transform: "scale(1.08)" },
-                "&:hover .MuiCardContent-root": { opacity: 1 },
+                borderRadius: 0,
+                bgcolor: INK,
+                border: `3px solid ${PAPER}`,
+                boxShadow: nbShadow(6, ACCENT),
+                transition: "transform 120ms ease, box-shadow 120ms ease",
+                "&:hover": {
+                  transform: "translate(-2px, -2px)",
+                  boxShadow: nbShadow(8, ACCENT),
+                },
               }}
             >
               <CardMedia
@@ -111,25 +116,22 @@ export default function VideoPhotoPage() {
                 height={192}
                 sx={{
                   height: 192,
-                  transition: "transform 300ms ease",
                   objectFit: "cover",
                 }}
               />
               <CardContent
                 sx={{
-                  position: "absolute",
-                  bottom: 0,
-                  left: 0,
-                  right: 0,
-                  bgcolor: "rgba(0,0,0,0.5)",
-                  color: "common.white",
+                  bgcolor: INK,
+                  borderTop: `2px solid ${PAPER}`,
+                  color: PAPER,
                   textAlign: "center",
                   py: 1,
-                  opacity: 0,
-                  transition: "opacity 300ms ease",
+                  "&:last-child": { pb: 1 },
                 }}
               >
-                <Typography variant="body2">{image.caption}</Typography>
+                <Typography variant="body2" sx={{ fontWeight: 700 }}>
+                  {image.caption}
+                </Typography>
               </CardContent>
             </Card>
           ))}

--- a/components/ui/glare-card.tsx
+++ b/components/ui/glare-card.tsx
@@ -1,6 +1,11 @@
 import { cn } from "@/lib/utils";
-import { useRef } from "react";
 
+/**
+ * Neobrutalist card (formerly a 3D glare/foil card).
+ * Ink surface, thick paper border, hard accent offset shadow, and the house
+ * translate-on-hover / press-down-on-active mechanic. No gradients, no blur.
+ * The component API (children + className) is unchanged.
+ */
 export const GlareCard = ({
   children,
   className,
@@ -8,125 +13,10 @@ export const GlareCard = ({
   children: React.ReactNode;
   className?: string;
 }) => {
-  const isPointerInside = useRef(false);
-  const refElement = useRef<HTMLDivElement>(null);
-  const state = useRef({
-    glare: {
-      x: 50,
-      y: 50,
-    },
-    background: {
-      x: 50,
-      y: 50,
-    },
-    rotate: {
-      x: 0,
-      y: 0,
-    },
-  });
-  const containerStyle = {
-    "--m-x": "50%",
-    "--m-y": "50%",
-    "--r-x": "0deg",
-    "--r-y": "0deg",
-    "--bg-x": "50%",
-    "--bg-y": "50%",
-    "--duration": "300ms",
-    "--foil-size": "100%",
-    "--opacity": "0",
-    "--radius": "24px",
-    "--easing": "ease",
-    "--transition": "var(--duration) var(--easing)",
-  } as any;
-
-  const backgroundStyle = {
-    "--step": "5%",
-    "--foil-svg": `url("data:image/svg+xml,%3Csvg width='26' height='26' viewBox='0 0 26 26' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M2.99994 3.419C2.99994 3.419 21.6142 7.43646 22.7921 12.153C23.97 16.8695 3.41838 23.0306 3.41838 23.0306' stroke='white' stroke-width='5' stroke-miterlimit='3.86874' stroke-linecap='round' style='mix-blend-mode:darken'/%3E%3C/svg%3E")`,
-    "--pattern": "var(--foil-svg) center/100% no-repeat",
-    "--rainbow":
-      "repeating-linear-gradient( 0deg,rgb(255,119,115) calc(var(--step) * 1),rgba(255,237,95,1) calc(var(--step) * 2),rgba(168,255,95,1) calc(var(--step) * 3),rgba(131,255,247,1) calc(var(--step) * 4),rgba(120,148,255,1) calc(var(--step) * 5),rgb(216,117,255) calc(var(--step) * 6),rgb(255,119,115) calc(var(--step) * 7) ) 0% var(--bg-y)/200% 700% no-repeat",
-    "--diagonal":
-      "repeating-linear-gradient( 128deg,#0e152e 0%,hsl(180,10%,60%) 3.8%,hsl(180,10%,60%) 4.5%,hsl(180,10%,60%) 5.2%,#0e152e 10%,#0e152e 12% ) var(--bg-x) var(--bg-y)/300% no-repeat",
-    "--shade":
-      "radial-gradient( farthest-corner circle at var(--m-x) var(--m-y),rgba(255,255,255,0.1) 12%,rgba(255,255,255,0.15) 20%,rgba(255,255,255,0.25) 120% ) var(--bg-x) var(--bg-y)/300% no-repeat",
-    backgroundBlendMode: "hue, hue, hue, overlay",
-  };
-
-  const updateStyles = () => {
-    if (refElement.current) {
-      console.log(state.current);
-      const { background, rotate, glare } = state.current;
-      refElement.current?.style.setProperty("--m-x", `${glare.x}%`);
-      refElement.current?.style.setProperty("--m-y", `${glare.y}%`);
-      refElement.current?.style.setProperty("--r-x", `${rotate.x}deg`);
-      refElement.current?.style.setProperty("--r-y", `${rotate.y}deg`);
-      refElement.current?.style.setProperty("--bg-x", `${background.x}%`);
-      refElement.current?.style.setProperty("--bg-y", `${background.y}%`);
-    }
-  };
   return (
-    <div
-      style={containerStyle}
-      className="relative isolate [contain:layout_style] [perspective:600px] transition-transform duration-[var(--duration)] ease-[var(--easing)] delay-[var(--delay)] will-change-transform w-full max-w-[160px] sm:max-w-[200px] md:max-w-[280px] lg:max-w-[340px] xl:max-w-[400px] [aspect-ratio:17/21]"
-      ref={refElement}
-      onPointerMove={(event) => {
-        const rotateFactor = 0.4;
-        const rect = event.currentTarget.getBoundingClientRect();
-        const position = {
-          x: event.clientX - rect.left,
-          y: event.clientY - rect.top,
-        };
-        const percentage = {
-          x: (100 / rect.width) * position.x,
-          y: (100 / rect.height) * position.y,
-        };
-        const delta = {
-          x: percentage.x - 50,
-          y: percentage.y - 50,
-        };
-
-        const { background, rotate, glare } = state.current;
-        background.x = 50 + percentage.x / 4 - 12.5;
-        background.y = 50 + percentage.y / 3 - 16.67;
-        rotate.x = -(delta.x / 3.5);
-        rotate.y = delta.y / 2;
-        rotate.x *= rotateFactor;
-        rotate.y *= rotateFactor;
-        glare.x = percentage.x;
-        glare.y = percentage.y;
-
-        updateStyles();
-      }}
-      onPointerEnter={() => {
-        isPointerInside.current = true;
-        if (refElement.current) {
-          setTimeout(() => {
-            if (isPointerInside.current) {
-              refElement.current?.style.setProperty("--duration", "0s");
-            }
-          }, 300);
-        }
-      }}
-      onPointerLeave={() => {
-        isPointerInside.current = false;
-        if (refElement.current) {
-          refElement.current.style.removeProperty("--duration");
-          refElement.current?.style.setProperty("--r-x", `0deg`);
-          refElement.current?.style.setProperty("--r-y", `0deg`);
-        }
-      }}
-    >
-      <div className="h-full grid will-change-transform origin-center transition-transform duration-[var(--duration)] ease-[var(--easing)] delay-[var(--delay)] [transform:rotateY(var(--r-x))_rotateX(var(--r-y))] rounded-[var(--radius)] border border-slate-800 hover:[--opacity:0.6] hover:[--duration:200ms] hover:[--easing:linear] hover:filter-none overflow-hidden">
-        <div className="w-full h-full grid [grid-area:1/1] mix-blend-soft-light [clip-path:inset(0_0_0_0_round_var(--radius))]">
-          <div className={cn("h-full w-full bg-slate-950", className)}>
-            {children}
-          </div>
-        </div>
-        <div className="w-full h-full grid [grid-area:1/1] mix-blend-soft-light [clip-path:inset(0_0_1px_0_round_var(--radius))] opacity-[var(--opacity)] transition-opacity transition-background duration-[var(--duration)] ease-[var(--easing)] delay-[var(--delay)] will-change-background [background:radial-gradient(farthest-corner_circle_at_var(--m-x)_var(--m-y),_rgba(255,255,255,0.8)_10%,_rgba(255,255,255,0.65)_20%,_rgba(255,255,255,0)_90%)]" />
-        {/* <div
-          className="w-full h-full grid [grid-area:1/1] mix-blend-color-dodge opacity-[var(--opacity)] will-change-background transition-opacity [clip-path:inset(0_0_1px_0_round_var(--radius))] [background-blend-mode:hue_hue_hue_overlay] [background:var(--pattern),_var(--rainbow),_var(--diagonal),_var(--shade)] relative after:content-[''] after:grid-area-[inherit] after:bg-repeat-[inherit] after:bg-attachment-[inherit] after:bg-origin-[inherit] after:bg-clip-[inherit] after:bg-[inherit] after:mix-blend-exclusion after:[background-size:var(--foil-size),_200%_400%,_800%,_200%] after:[background-position:center,_0%_var(--bg-y),_calc(var(--bg-x)*_-1)_calc(var(--bg-y)*_-1),_var(--bg-x)_var(--bg-y)] after:[background-blend-mode:soft-light,_hue,_hard-light]"
-          style={{ ...backgroundStyle }}
-        /> */}
+    <div className="w-full max-w-[160px] sm:max-w-[200px] md:max-w-[280px] lg:max-w-[340px] xl:max-w-[400px] [aspect-ratio:17/21] overflow-hidden border-[3px] border-[#F3EDE2] bg-[#111111] shadow-[8px_8px_0_0_#C0C0C0] transition-[transform,box-shadow] duration-150 ease-out hover:-translate-x-[2px] hover:-translate-y-[2px] hover:shadow-[10px_10px_0_0_#C0C0C0] active:translate-x-[2px] active:translate-y-[2px] active:shadow-none">
+      <div className={cn("h-full w-full bg-[#111111]", className)}>
+        {children}
       </div>
     </div>
   );

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -1,19 +1,119 @@
-export const BRAND_ACCENT = "#E5C767";
-export const BRAND_ACCENT_DEEP = "#C9A227";
+/**
+ * DripDome neobrutalist design tokens.
+ *
+ * The system: flat saturated color, thick ink borders, hard offset shadows
+ * (zero blur), zero border radius, and press-down button mechanics.
+ * No gradients anywhere.
+ */
 
-export const BRAND_GRADIENT =
-  "linear-gradient(135deg, #E5C767 0%, #E89B3C 100%)";
+/** Near-black used for text, borders, and dark section backgrounds. */
+export const INK = "#111111";
+/** Warm bone paper used for page/section backgrounds. */
+export const PAPER = "#F3EDE2";
+/** Card surface color on paper backgrounds. */
+export const SURFACE = "#ff9966";
+/** Light Tiffany blue. Flat only, never in a gradient. */
+export const ACCENT = "#81D8D0";
+/** Safety orange. Use sparingly: tags, hovers, one accent word per page. */
+export const POP = "#FF5C00";
 
+/** Standard borders. Thick = cards/buttons/inputs, thin = small UI. */
+export const NB_BORDER = `3px solid ${INK}`;
+export const NB_BORDER_THIN = `2px solid ${INK}`;
+
+/** Hard offset shadow, zero blur. Pass PAPER or ACCENT for dark backgrounds. */
+export const nbShadow = (px = 4, color: string = INK) =>
+  `${px}px ${px}px 0 0 ${color}`;
+
+/** Card on a light background: white surface, ink border, hard shadow. */
+export const NB_CARD_SX = {
+  bgcolor: SURFACE,
+  border: NB_BORDER,
+  borderRadius: 0,
+  boxShadow: nbShadow(8),
+} as const;
+
+/** Card on a dark (ink) background: ink surface, paper border, accent shadow. */
+export const NB_CARD_DARK_SX = {
+  bgcolor: INK,
+  border: `3px solid ${PAPER}`,
+  borderRadius: 0,
+  boxShadow: nbShadow(8, ACCENT),
+} as const;
+
+/** Primary CTA: flat Tiffany blue, ink border, hard shadow, press-down mechanics. */
+export const NB_BUTTON_SX = {
+  bgcolor: ACCENT,
+  color: INK,
+  border: NB_BORDER,
+  borderRadius: 0,
+  boxShadow: nbShadow(4),
+  fontWeight: 700,
+  textTransform: "uppercase",
+  transition: "transform 120ms ease, box-shadow 120ms ease",
+  "&:hover": {
+    bgcolor: ACCENT,
+    transform: "translate(-2px, -2px)",
+    boxShadow: nbShadow(6),
+  },
+  "&:active": {
+    transform: "translate(2px, 2px)",
+    boxShadow: nbShadow(0),
+  },
+} as const;
+
+/** Secondary button on dark backgrounds: transparent, paper border/shadow. */
+export const NB_BUTTON_OUTLINE_DARK_SX = {
+  bgcolor: "transparent",
+  color: PAPER,
+  border: `3px solid ${PAPER}`,
+  borderRadius: 0,
+  boxShadow: nbShadow(4, PAPER),
+  fontWeight: 700,
+  textTransform: "uppercase",
+  transition: "transform 120ms ease, box-shadow 120ms ease",
+  "&:hover": {
+    bgcolor: "transparent",
+    borderColor: ACCENT,
+    color: ACCENT,
+    transform: "translate(-2px, -2px)",
+    boxShadow: nbShadow(6, ACCENT),
+  },
+  "&:active": {
+    transform: "translate(2px, 2px)",
+    boxShadow: nbShadow(0, PAPER),
+  },
+} as const;
+
+/** Small square tag/badge on dark backgrounds. */
+export const NB_TAG_DARK_SX = {
+  px: 1.5,
+  py: 0.5,
+  border: `2px solid ${PAPER}`,
+  borderRadius: 0,
+  bgcolor: INK,
+  color: PAPER,
+  boxShadow: nbShadow(3, ACCENT),
+  fontWeight: 700,
+  letterSpacing: "0.08em",
+  textTransform: "uppercase",
+} as const;
+
+/* ------------------------------------------------------------------ */
+/* Legacy names kept so existing imports keep compiling.               */
+/* They now resolve to flat neobrutalist styles: no gradients remain.  */
+/* ------------------------------------------------------------------ */
+
+export const BRAND_ACCENT = ACCENT;
+export const BRAND_ACCENT_DEEP = POP;
+
+/** Flat accent. Still valid anywhere it was used as a CSS `background`. */
+export const BRAND_GRADIENT = ACCENT;
+
+/** Accent text is now flat Tiffany blue. */
 export const BRAND_GRADIENT_TEXT_SX = {
-  background: BRAND_GRADIENT,
-  backgroundClip: "text",
-  WebkitBackgroundClip: "text",
-  WebkitTextFillColor: "transparent",
-  color: "transparent",
+  color: ACCENT,
 } as const;
 
-export const BRAND_GRADIENT_BUTTON_SX = {
-  background: BRAND_GRADIENT,
-  color: "black",
-  "&:hover": { filter: "brightness(0.92)", background: BRAND_GRADIENT },
-} as const;
+/** Primary CTAs now use the neobrutalist button. */
+export const BRAND_GRADIENT_BUTTON_SX = NB_BUTTON_SX;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -10,7 +10,21 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      fontFamily: {
+        display: ["var(--font-display)", "system-ui", "sans-serif"],
+        body: ["var(--font-body)", "system-ui", "sans-serif"],
+      },
+      boxShadow: {
+        brutal: "4px 4px 0 0 #111111",
+        "brutal-lg": "8px 8px 0 0 #111111",
+        "brutal-silver": "4px 4px 0 0 #C0C0C0",
+        "brutal-paper": "4px 4px 0 0 #F3EDE2",
+      },
       colors: {
+        ink: "#111111",
+        paper: "#F3EDE2",
+        silver: "#C0C0C0",
+        pop: "#FF5C00",
         background: "hsl(var(--background))",
         foreground: "hsl(var(--foreground))",
         card: {


### PR DESCRIPTION
Replaces the champagne-gold gradient aesthetic with a flat neobrutalist system across the entire site: ink/paper/accent color tokens, thick ink borders, hard zero-blur offset shadows, zero border radius, and press-down button mechanics. Swaps fonts to Archivo Black (display) and Space Grotesk (body), and rewrites the MUI theme, Tailwind config, and global CSS. Every route, section, form, card, and carousel was converted, and the design system is documented in CLAUDE.md. Form logic, analytics, and SEO/JSON-LD were left untouched. Verified with a passing type-check and production build.