### PR TITLE
Neobrutalist redesign: new design system, vertical IA, full site conversion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ npx tsc --noEmit     # Type-check without emitting
 
 `app/layout.tsx` (server) loads Google Fonts (Source Sans 3), JSON-LD, Vercel Analytics, and the GTM container (conditional on `NEXT_PUBLIC_GTM_ID`). It wraps children in:
 - `ThemeRegistry.tsx` - MUI Emotion cache + ThemeProvider
-- `ClientLayout.tsx` - hides Navbar on the home route (`/`) only; all other routes show it
+- `ClientLayout.tsx` - renders the Navbar on every route (sticky, in normal flow, so no spacer hacks)
 
 The home page (`app/page.tsx`) is a single scroll of section components imported from `app/components/`.
 
@@ -27,22 +27,23 @@ The home page (`app/page.tsx`) is a single scroll of section components imported
 
 Hybrid approach: **MUI sx prop** for component-level styles, **Tailwind** for utility classes, **Emotion** under the hood for MUI. The `cn()` helper in `lib/utils.ts` merges clsx + tailwind-merge.
 
-Brand colors defined in `app/theme.ts`: surface `#FFFFFF`, ink `#111111`, accent `#E5C767` (champagne gold). MUI palette uses `#FCF5EC` (brown/cream) as primary and `#DD9F28` (gold) as secondary.
+**Neobrutalist design system (current direction)** lives in `lib/theme.ts`. The entire palette is centralized in the `NB_COLORS` object, currently a dark-mode white/black/silver scheme: near-black `paper` page background, off-white `ink` for text/borders/inverted bands, `silver` accents. Semantic tokens keep inversion safe: `paperOnInk` (text on ink bands), `onSilver` (text on silver fills, always dark), `mutedOnInk` (muted text/rules on ink bands), and `well` (media backdrop that must stay dark in ANY theme because the brand/press logo PNGs are white artwork). To retheme the site, edit `NB_COLORS` (plus `NB_BORDER_WIDTH` / `NB_SHADOW_OFFSET` for chunkier hardware). Never hardcode hex values in components; always import tokens.
 
-Shared brand tokens live in `lib/theme.ts`:
-- `BRAND_ACCENT` (`#E5C767`) and `BRAND_ACCENT_DEEP` (`#C9A227`) — solid colors for icons, pill borders, active-nav underline, hover states, and any UI under ~20px where a gradient would read as muddy
-- `BRAND_GRADIENT` — `linear-gradient(135deg, #E5C767 → #E89B3C)`
-- `BRAND_GRADIENT_TEXT_SX` — spread into an sx object on big accent text (hero H1 spans, section H2 accent words, the huge case-study numbers)
-- `BRAND_GRADIENT_BUTTON_SX` — spread into an sx object on primary CTA buttons (uses `filter: brightness(0.92)` on hover)
+Derived tokens: `NB_RULE` (2px ink border used everywhere), `nbShadow()` (hard zero-blur offset shadow), `NB_DISPLAY_SX` (Archivo Black headline type), `NB_MONO_SX` (IBM Plex Mono spec-sheet labels), `NB_OUTLINE_TEXT_SX` (stroke-only display text), `NB_BUTTON_SX` / `NB_BUTTON_OUTLINE_SX` (press-down mechanic buttons), `NB_TAG_SX` (square chips). Fonts are registered in `app/layout.tsx` via next/font CSS variables (`--font-display`, `--font-mono`).
 
-**Rule of thumb for the gradient**: apply only to hero-scale text and primary CTAs. Keep icons, tiny borders, navbar underline, and body-copy accents on the solid `BRAND_ACCENT` color.
+Visual grammar: flat colors, 2px ink rules dividing full-width section bands, hard offset shadows, zero border radius, uppercase display type, mono metadata labels (job numbers, figure captions, indexes), inverted ink bands, marquee tickers (`nb-ticker` keyframe in `globals.css`).
+
+Every active route is converted to this system. The legacy champagne-gold tokens (`BRAND_ACCENT`, `BRAND_GRADIENT*` at the bottom of `lib/theme.ts`) are referenced only by dead components that are not imported anywhere (`HomeBlurb`, `Chatbot`, `ProjectsContributed`, `WorkReel`, `OurServices`); never use them in new work. Swiper card/fade carousels have been replaced site-wide with scroll-snap filmstrips (frame counter + square arrow controls, pattern in `JobFile.tsx`).
 
 ### Routes
 
+The site is organized around two specialty verticals (podcast studios, brand activations) with the home page acting as the master work archive. Set design and music videos are sunset services: kept in the archive index and taken "for the right project," but not promoted with dedicated pages or nav items. `/portfolio`, `/services`, and `/rentals` remain live but are intentionally out of the nav.
+
 | Route | Purpose |
 |-------|---------|
-| `/` | Home (scroll sections) |
-| `/brand-activations` | Google Ads landing page. Budget-qualified inquiry form fires `generate_lead` conversion |
+| `/` | Home: hero, specialties router ("What do you need built?"), master work archive (featured job files + full index) |
+| `/podcast-studios` | Vertical landing page for podcasters/networks. Hero, proof band, build spec sheet, shipped builds, intake |
+| `/brand-activations` | Vertical landing page + Google Ads LP. Budget-qualified inquiry form fires `generate_lead` conversion |
 | `/blog` | Blog listing with category filtering |
 | `/blog/[slug]` | Dynamic blog post pages |
 | `/blog/feed.xml` | RSS feed (route handler) |
@@ -56,6 +57,8 @@ Shared brand tokens live in `lib/theme.ts`:
 ### Data Pattern
 
 Blog, portfolio, rentals, and services data live in co-located `data.ts` files (e.g., `app/blog/data.ts`). No database. Blog posts store full HTML content as template literal strings in the `content` field.
+
+**Project registry**: `lib/projects.ts` is the single source of truth for build projects. Each `Project` has a `vertical` key (`podcast`, `activation`, `setDesign`, `musicVideo` — the latter two flagged `legacy`), images, stats, and a `featured` flag. The home archive renders featured projects as full job files plus a complete index table; vertical pages filter with `projectsByVertical()`. Add a project there and it flows to every surface.
 
 ### API
 
@@ -94,6 +97,8 @@ Every page route exports `metadata` with Open Graph, Twitter cards, and canonica
 ### Reusable Section Components
 
 `app/components/` holds sections reused across multiple pages:
+- `JobFile` — project case sheet (ink header bar with job no./vertical tag/client, scroll-snap filmstrip with frame counter, title + stat chips + blurb). Consumes a `Project` from `lib/projects.ts`. Used on home archive and vertical pages
+- `Specialties` — "What do you need built?" two-panel intent router (podcast studios / brand activations) with sunset-services strip
 - `SocialProofBar` — 4-stat animated counter row (used on home and `/brand-activations`)
 - `TrustWall` (default) — "Trusted By" + logo marquee. `TrustPress` (named export) — "In the Press" link list. Originally one component, split so each page can place them independently
 - `FeaturedProjects` — Swiper card-effect carousel of project case studies

--- a/app/about-us/page.tsx
+++ b/app/about-us/page.tsx
@@ -3,6 +3,7 @@ import { Box } from "@mui/material";
 import AboutUs from "../components/AboutUs";
 import FoundersSection from "../components/FoundersSection";
 import Contact from "../components/Contact";
+import { NB_COLORS } from "@/lib/theme";
 
 export const metadata: Metadata = {
   title: "About Us | DripDome - Women-Owned Set Design Studio NYC",
@@ -41,10 +42,10 @@ export const metadata: Metadata = {
 
 export default function AboutUsPage() {
   return (
-    <Box>
+    <Box component="main" sx={{ bgcolor: NB_COLORS.paper, color: NB_COLORS.ink }}>
       <AboutUs />
       <FoundersSection />
-      <Box sx={{ bgcolor: "black", py: 10 }}>
+      <Box id="contact" sx={{ scrollMarginTop: { xs: 95, md: 120 } }}>
         <Contact />
       </Box>
     </Box>

--- a/app/blog/BlogContent.tsx
+++ b/app/blog/BlogContent.tsx
@@ -3,10 +3,47 @@
 import { useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
-import { Box, Typography, Chip } from "@mui/material";
+import { Box, ButtonBase, Typography } from "@mui/material";
 import { motion } from "framer-motion";
+import ArrowOutwardIcon from "@mui/icons-material/ArrowOutward";
 import { blogPosts, getAllCategories } from "./data";
-import { BRAND_GRADIENT_TEXT_SX } from "@/lib/theme";
+import {
+  NB_COLORS,
+  NB_DISPLAY_SX,
+  NB_MONO_SX,
+  NB_RULE,
+  NB_TAG_SX,
+} from "@/lib/theme";
+
+function FilterButton({
+  label,
+  active,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <ButtonBase
+      onClick={onClick}
+      aria-pressed={active}
+      sx={{
+        ...NB_TAG_SX,
+        fontSize: 11,
+        fontWeight: 700,
+        cursor: "pointer",
+        bgcolor: active ? NB_COLORS.ink : NB_COLORS.surface,
+        color: active ? NB_COLORS.paperOnInk : NB_COLORS.ink,
+        "&:hover": {
+          bgcolor: active ? NB_COLORS.ink : NB_COLORS.silverLight,
+        },
+      }}
+    >
+      {label}
+    </ButtonBase>
+  );
+}
 
 export default function BlogContent() {
   const categories = getAllCategories();
@@ -17,290 +54,251 @@ export default function BlogContent() {
     : blogPosts;
 
   return (
-    <Box sx={{ bgcolor: "black", overflow: "hidden", minHeight: "100vh" }}>
-      {/* Hero Section */}
-      <Box
-        sx={{
-          maxWidth: "1200px",
-          mx: "auto",
-          px: { xs: 2, md: 6 },
-          pt: { xs: 6, md: 10 },
-          pb: { xs: 4, md: 6 },
-        }}
-      >
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6 }}
+    <Box component="main" sx={{ bgcolor: NB_COLORS.paper, minHeight: "100vh" }}>
+      {/* Hero band */}
+      <Box component="section" sx={{ borderBottom: NB_RULE }}>
+        <Box
+          sx={{
+            px: { xs: 3, md: 6 },
+            py: { xs: 5, md: 8 },
+            maxWidth: 1440,
+            mx: "auto",
+          }}
         >
-          <Typography
-            variant="h1"
-            sx={{
-              fontSize: { xs: "42px", sm: "64px", md: "80px", lg: "96px" },
-              fontWeight: 800,
-              color: "white",
-              textAlign: "center",
-              mb: { xs: 3, md: 4 },
-              letterSpacing: "-0.02em",
-            }}
+          <motion.div
+            initial={{ opacity: 0, y: 16 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5 }}
           >
-            THE{" "}
-            <Box
-              component="span"
-              sx={{ display: "inline", ...BRAND_GRADIENT_TEXT_SX }}
+            <Typography
+              sx={{ ...NB_MONO_SX, fontSize: 12, color: NB_COLORS.steel, mb: 2 }}
             >
-              BLOG
-            </Box>
-          </Typography>
-        </motion.div>
+              DRIPDOME JOURNAL · FIELD NOTES FROM THE SHOP
+            </Typography>
+          </motion.div>
 
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.15, duration: 0.6 }}
-        >
-          <Typography
-            sx={{
-              fontSize: { xs: "16px", sm: "18px", md: "22px" },
-              color: "rgba(255,255,255,0.85)",
-              textAlign: "center",
-              maxWidth: "900px",
-              mx: "auto",
-              lineHeight: 1.7,
-            }}
+          <motion.div
+            initial={{ opacity: 0, y: 24 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.1 }}
           >
-            Behind-the-scenes looks at our builds, fabrication deep dives, and
-            insights from the{" "}
-            <Box component="span" sx={{ color: "#E5C767", fontWeight: 600 }}>
-              DripDome
-            </Box>{" "}
-            studio.
-          </Typography>
-        </motion.div>
-      </Box>
-
-      {/* Category Filter */}
-      <Box
-        sx={{
-          maxWidth: "1200px",
-          mx: "auto",
-          px: { xs: 2, md: 6 },
-          pb: { xs: 3, md: 4 },
-        }}
-      >
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.25, duration: 0.6 }}
-        >
-          <Box
-            component="nav"
-            aria-label="Blog categories"
-            sx={{
-              display: "flex",
-              flexWrap: "wrap",
-              gap: 1,
-              justifyContent: "center",
-            }}
-          >
-            <Chip
-              label="All"
-              onClick={() => setActiveCategory(null)}
+            <Typography
+              variant="h1"
               sx={{
-                bgcolor: !activeCategory
-                  ? "#E5C767"
-                  : "rgba(255,255,255,0.08)",
-                color: "white",
-                fontWeight: 600,
-                fontSize: "14px",
-                "&:hover": {
-                  bgcolor: !activeCategory
-                    ? "#E5C767"
-                    : "rgba(255,255,255,0.15)",
-                },
+                ...NB_DISPLAY_SX,
+                fontSize: { xs: 44, sm: 64, md: 80, lg: 96 },
+                color: NB_COLORS.ink,
+                mb: 3,
               }}
-            />
-            {categories.map((category) => (
-              <Chip
-                key={category}
-                label={category}
-                onClick={() => setActiveCategory(category)}
-                sx={{
-                  bgcolor:
-                    activeCategory === category
-                      ? "#E5C767"
-                      : "rgba(255,255,255,0.08)",
-                  color: "white",
-                  fontWeight: 600,
-                  fontSize: "14px",
-                  "&:hover": {
-                    bgcolor:
-                      activeCategory === category
-                        ? "#E5C767"
-                        : "rgba(255,255,255,0.15)",
-                  },
-                }}
-              />
-            ))}
-          </Box>
-        </motion.div>
+            >
+              THE JOURNAL
+            </Typography>
+          </motion.div>
+
+          <motion.div
+            initial={{ opacity: 0, y: 16 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.2 }}
+          >
+            <Typography
+              sx={{
+                fontSize: { xs: 16, md: 18 },
+                color: NB_COLORS.ink,
+                maxWidth: 640,
+              }}
+            >
+              Behind-the-scenes looks at our builds, fabrication deep dives,
+              and insights from the DripDome studio.
+            </Typography>
+          </motion.div>
+        </Box>
       </Box>
 
-      {/* Blog Post Grid */}
+      {/* Category filter band */}
       <Box
-        component="section"
-        aria-label="Blog posts"
+        component="nav"
+        aria-label="Blog categories"
         sx={{
-          maxWidth: "1200px",
-          mx: "auto",
-          px: { xs: 2, md: 6 },
-          pb: { xs: 6, md: 10 },
+          display: "flex",
+          flexWrap: "wrap",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 2,
+          px: { xs: 3, md: 6 },
+          py: { xs: 2, md: 2.5 },
+          borderBottom: NB_RULE,
         }}
       >
         <Box
           sx={{
-            display: "grid",
-            gridTemplateColumns: {
-              xs: "1fr",
-              sm: "1fr 1fr",
-              lg: "1fr 1fr 1fr",
-            },
-            gap: { xs: 3, md: 4 },
+            display: "flex",
+            flexWrap: "wrap",
+            alignItems: "center",
+            gap: 1,
           }}
         >
-          {filteredPosts.map((post, index) => (
-            <motion.article
-              key={post.slug}
-              initial={{ opacity: 0, y: 30 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: index * 0.1, duration: 0.5 }}
-            >
-              <Link
-                href={`/blog/${post.slug}`}
-                style={{ textDecoration: "none" }}
-              >
-                <Box
-                  sx={{
-                    borderRadius: 3,
-                    overflow: "hidden",
-                    bgcolor: "rgba(255,255,255,0.03)",
-                    border: "1px solid rgba(255,255,255,0.1)",
-                    transition: "all 0.3s ease",
-                    height: "100%",
-                    display: "flex",
-                    flexDirection: "column",
-                    "&:hover": {
-                      bgcolor: "rgba(255,255,255,0.06)",
-                      borderColor: "rgba(229,199,103,0.5)",
-                      transform: "translateY(-4px)",
-                    },
-                  }}
-                >
-                  {/* Post Image */}
-                  <Box
-                    sx={{
-                      position: "relative",
-                      width: "100%",
-                      height: 200,
-                      bgcolor: "rgba(255,255,255,0.05)",
-                    }}
-                  >
-                    <Image
-                      src={post.image.url}
-                      alt={post.image.alt}
-                      fill
-                      style={{ objectFit: "cover" }}
-                      sizes="(max-width: 600px) 100vw, (max-width: 1200px) 50vw, 33vw"
-                    />
-                  </Box>
-
-                  {/* Post Content */}
-                  <Box
-                    sx={{
-                      p: { xs: 2.5, md: 3 },
-                      flex: 1,
-                      display: "flex",
-                      flexDirection: "column",
-                    }}
-                  >
-                    {/* Category + Reading Time */}
-                    <Box
-                      sx={{
-                        display: "flex",
-                        alignItems: "center",
-                        justifyContent: "space-between",
-                        mb: 1.5,
-                      }}
-                    >
-                      <Typography
-                        sx={{
-                          fontSize: "12px",
-                          fontWeight: 700,
-                          color: "#E5C767",
-                          letterSpacing: "0.1em",
-                          textTransform: "uppercase",
-                        }}
-                      >
-                        {post.category}
-                      </Typography>
-                      <Typography
-                        sx={{
-                          fontSize: "12px",
-                          color: "rgba(255,255,255,0.5)",
-                        }}
-                      >
-                        {post.readingTime}
-                      </Typography>
-                    </Box>
-
-                    {/* Title */}
-                    <Typography
-                      component="h2"
-                      sx={{
-                        fontSize: { xs: "18px", md: "20px" },
-                        fontWeight: 700,
-                        color: "white",
-                        lineHeight: 1.3,
-                        mb: 1.5,
-                      }}
-                    >
-                      {post.title}
-                    </Typography>
-
-                    {/* Excerpt */}
-                    <Typography
-                      sx={{
-                        fontSize: { xs: "14px", md: "15px" },
-                        color: "rgba(255,255,255,0.7)",
-                        lineHeight: 1.6,
-                        flex: 1,
-                      }}
-                    >
-                      {post.excerpt}
-                    </Typography>
-
-                    {/* Date */}
-                    <Typography
-                      component="time"
-                      dateTime={post.date}
-                      sx={{
-                        fontSize: "13px",
-                        color: "rgba(255,255,255,0.4)",
-                        mt: 2,
-                      }}
-                    >
-                      {new Date(post.date).toLocaleDateString("en-US", {
-                        year: "numeric",
-                        month: "long",
-                        day: "numeric",
-                      })}
-                    </Typography>
-                  </Box>
-                </Box>
-              </Link>
-            </motion.article>
+          <Typography
+            sx={{ ...NB_MONO_SX, fontSize: 11, color: NB_COLORS.steel, mr: 1 }}
+          >
+            FILTER:
+          </Typography>
+          <FilterButton
+            label="ALL"
+            active={!activeCategory}
+            onClick={() => setActiveCategory(null)}
+          />
+          {categories.map((category) => (
+            <FilterButton
+              key={category}
+              label={category}
+              active={activeCategory === category}
+              onClick={() => setActiveCategory(category)}
+            />
           ))}
         </Box>
+        <Typography sx={{ ...NB_MONO_SX, fontSize: 11, color: NB_COLORS.steel }}>
+          INDEX · {String(filteredPosts.length).padStart(2, "0")}{" "}
+          {filteredPosts.length === 1 ? "ENTRY" : "ENTRIES"}
+        </Typography>
+      </Box>
+
+      {/* Editorial index */}
+      <Box component="section" aria-label="Blog posts">
+        {filteredPosts.map((post, index) => (
+          <motion.article
+            key={post.slug}
+            initial={{ opacity: 0, y: 24 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: index * 0.06, duration: 0.5 }}
+          >
+            <Box
+              component={Link}
+              href={`/blog/${post.slug}`}
+              sx={{
+                display: "grid",
+                gridTemplateColumns: { xs: "1fr", md: "64px 260px 1fr 48px" },
+                gap: { xs: 2, md: 4 },
+                alignItems: "center",
+                px: { xs: 3, md: 6 },
+                py: { xs: 3, md: 3.5 },
+                borderBottom: NB_RULE,
+                textDecoration: "none",
+                color: NB_COLORS.ink,
+                "&:hover": {
+                  bgcolor: NB_COLORS.ink,
+                  color: NB_COLORS.paperOnInk,
+                  "& .journal-meta": { color: NB_COLORS.mutedOnInk },
+                },
+              }}
+            >
+              {/* Entry index */}
+              <Typography
+                className="journal-meta"
+                sx={{
+                  ...NB_MONO_SX,
+                  fontSize: 12,
+                  color: NB_COLORS.steel,
+                  display: { xs: "none", md: "block" },
+                }}
+              >
+                E.{String(index + 1).padStart(2, "0")}
+              </Typography>
+
+              {/* Thumbnail */}
+              <Box
+                sx={{
+                  position: "relative",
+                  width: "100%",
+                  height: { xs: 200, md: 150 },
+                  border: NB_RULE,
+                  bgcolor: NB_COLORS.well,
+                }}
+              >
+                <Image
+                  src={post.image.url}
+                  alt={post.image.alt}
+                  fill
+                  style={{ objectFit: "cover" }}
+                  sizes="(max-width: 900px) 100vw, 260px"
+                />
+              </Box>
+
+              {/* Entry copy */}
+              <Box>
+                <Box
+                  sx={{
+                    display: "flex",
+                    flexWrap: "wrap",
+                    gap: 1.5,
+                    mb: 1,
+                  }}
+                >
+                  <Typography
+                    className="journal-meta"
+                    sx={{
+                      ...NB_MONO_SX,
+                      fontSize: 11,
+                      fontWeight: 700,
+                      color: NB_COLORS.steel,
+                    }}
+                  >
+                    {post.category}
+                  </Typography>
+                  <Typography
+                    className="journal-meta"
+                    component="time"
+                    dateTime={post.date}
+                    sx={{ ...NB_MONO_SX, fontSize: 11, color: NB_COLORS.steel }}
+                  >
+                    {new Date(post.date).toLocaleDateString("en-US", {
+                      year: "numeric",
+                      month: "long",
+                      day: "numeric",
+                    })}
+                  </Typography>
+                  <Typography
+                    className="journal-meta"
+                    sx={{ ...NB_MONO_SX, fontSize: 11, color: NB_COLORS.steel }}
+                  >
+                    {post.readingTime}
+                  </Typography>
+                </Box>
+
+                <Typography
+                  component="h2"
+                  sx={{
+                    ...NB_DISPLAY_SX,
+                    fontSize: { xs: 20, md: 24 },
+                    color: "inherit",
+                    mb: 1,
+                  }}
+                >
+                  {post.title}
+                </Typography>
+
+                <Typography
+                  className="journal-meta"
+                  sx={{
+                    fontSize: { xs: 14, md: 15 },
+                    lineHeight: 1.6,
+                    color: NB_COLORS.steel,
+                  }}
+                >
+                  {post.excerpt}
+                </Typography>
+              </Box>
+
+              <ArrowOutwardIcon
+                sx={{
+                  fontSize: 22,
+                  color: "inherit",
+                  display: { xs: "none", md: "block" },
+                  justifySelf: "end",
+                }}
+              />
+            </Box>
+          </motion.article>
+        ))}
       </Box>
     </Box>
   );

--- a/app/blog/[slug]/BlogPostContent.tsx
+++ b/app/blog/[slug]/BlogPostContent.tsx
@@ -10,6 +10,28 @@ import { Autoplay } from "swiper/modules";
 import "swiper/css";
 import ContactForm from "../../components/ContactForm";
 import { getPostBySlug } from "../data";
+import {
+  FONT_DISPLAY,
+  FONT_MONO,
+  NB_COLORS,
+  NB_DISPLAY_SX,
+  NB_MONO_SX,
+  NB_RULE,
+  NB_TAG_SX,
+  nbShadow,
+} from "@/lib/theme";
+
+const CRUMB_SX = {
+  ...NB_MONO_SX,
+  fontSize: 11,
+  color: NB_COLORS.steel,
+} as const;
+
+const META_SX = {
+  ...NB_MONO_SX,
+  fontSize: 12,
+  color: NB_COLORS.steel,
+} as const;
 
 export default function BlogPostContent({ slug }: { slug: string }) {
   const post = getPostBySlug(slug);
@@ -22,18 +44,9 @@ export default function BlogPostContent({ slug }: { slug: string }) {
   });
 
   return (
-    <Box sx={{ bgcolor: "black", overflow: "hidden", minHeight: "100vh" }}>
-      <Box
-        component="article"
-        sx={{
-          maxWidth: "800px",
-          mx: "auto",
-          px: { xs: 2, md: 4 },
-          pt: { xs: 4, md: 8 },
-          pb: { xs: 6, md: 10 },
-        }}
-      >
-        {/* Breadcrumb Navigation */}
+    <Box sx={{ bgcolor: NB_COLORS.paper, minHeight: "100vh" }}>
+      <Box component="article">
+        {/* Breadcrumb band */}
         <motion.nav
           aria-label="Breadcrumb"
           initial={{ opacity: 0 }}
@@ -45,56 +58,51 @@ export default function BlogPostContent({ slug }: { slug: string }) {
             sx={{
               display: "flex",
               alignItems: "center",
-              gap: 1,
+              gap: 1.5,
               listStyle: "none",
-              p: 0,
               m: 0,
-              mb: { xs: 3, md: 4 },
+              px: { xs: 3, md: 6 },
+              py: 1.5,
+              borderBottom: NB_RULE,
             }}
           >
             <Box component="li">
-              <Link
+              <Box
+                component={Link}
                 href="/"
-                style={{
-                  color: "rgba(255,255,255,0.5)",
+                sx={{
+                  ...CRUMB_SX,
                   textDecoration: "none",
-                  fontSize: "14px",
+                  "&:hover": { color: NB_COLORS.ink },
                 }}
               >
                 Home
-              </Link>
+              </Box>
             </Box>
-            <Typography
-              component="li"
-              sx={{ color: "rgba(255,255,255,0.3)", fontSize: "14px" }}
-              aria-hidden="true"
-            >
+            <Typography component="li" sx={CRUMB_SX} aria-hidden="true">
               /
             </Typography>
             <Box component="li">
-              <Link
+              <Box
+                component={Link}
                 href="/blog"
-                style={{
-                  color: "rgba(255,255,255,0.5)",
+                sx={{
+                  ...CRUMB_SX,
                   textDecoration: "none",
-                  fontSize: "14px",
+                  "&:hover": { color: NB_COLORS.ink },
                 }}
               >
                 Blog
-              </Link>
+              </Box>
             </Box>
-            <Typography
-              component="li"
-              sx={{ color: "rgba(255,255,255,0.3)", fontSize: "14px" }}
-              aria-hidden="true"
-            >
+            <Typography component="li" sx={CRUMB_SX} aria-hidden="true">
               /
             </Typography>
             <Typography
               component="li"
               sx={{
-                color: "rgba(255,255,255,0.7)",
-                fontSize: "14px",
+                ...CRUMB_SX,
+                color: NB_COLORS.ink,
                 overflow: "hidden",
                 textOverflow: "ellipsis",
                 whiteSpace: "nowrap",
@@ -106,157 +114,130 @@ export default function BlogPostContent({ slug }: { slug: string }) {
           </Box>
         </motion.nav>
 
-        {/* Post Header */}
-        <Box component="header">
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-          >
-            {/* Category */}
-            <Typography
-              sx={{
-                fontSize: "13px",
-                fontWeight: 700,
-                color: "#E5C767",
-                letterSpacing: "0.15em",
-                textTransform: "uppercase",
-                mb: 2,
-              }}
+        {/* Post header band */}
+        <Box
+          component="header"
+          sx={{
+            borderBottom: NB_RULE,
+            px: { xs: 3, md: 6 },
+            py: { xs: 4, md: 6 },
+          }}
+        >
+          <Box sx={{ maxWidth: 800, mx: "auto" }}>
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.6 }}
             >
-              {post.category}
-            </Typography>
+              {/* Category */}
+              <Typography sx={{ ...META_SX, fontWeight: 700, mb: 2 }}>
+                {post.category}
+              </Typography>
 
-            {/* Title */}
-            <Typography
-              variant="h1"
-              sx={{
-                fontSize: { xs: "28px", sm: "36px", md: "44px" },
-                fontWeight: 800,
-                color: "white",
-                lineHeight: 1.2,
-                mb: 3,
-                letterSpacing: "-0.02em",
-              }}
-            >
-              {post.title}
-            </Typography>
+              {/* Title */}
+              <Typography
+                variant="h1"
+                sx={{
+                  ...NB_DISPLAY_SX,
+                  fontSize: { xs: 30, sm: 40, md: 48 },
+                  color: NB_COLORS.ink,
+                  mb: 3,
+                }}
+              >
+                {post.title}
+              </Typography>
 
-            {/* Meta */}
-            <Box
-              sx={{
-                display: "flex",
-                flexWrap: "wrap",
-                alignItems: "center",
-                gap: { xs: 1.5, md: 2 },
-                mb: { xs: 4, md: 5 },
-                pb: { xs: 3, md: 4 },
-                borderBottom: "1px solid rgba(255,255,255,0.1)",
-              }}
-            >
-              <Typography
+              {/* Meta */}
+              <Box
                 sx={{
-                  fontSize: "14px",
-                  color: "rgba(255,255,255,0.7)",
-                  fontWeight: 600,
+                  display: "flex",
+                  flexWrap: "wrap",
+                  alignItems: "center",
+                  gap: { xs: 1.5, md: 2 },
                 }}
               >
-                {post.author.name}
-              </Typography>
-              {post.author.role && (
-                <>
-                  <Typography
-                    sx={{ color: "rgba(255,255,255,0.3)", fontSize: "14px" }}
-                    aria-hidden="true"
-                  >
-                    |
-                  </Typography>
-                  <Typography
-                    sx={{
-                      fontSize: "14px",
-                      color: "rgba(255,255,255,0.5)",
-                    }}
-                  >
-                    {post.author.role}
-                  </Typography>
-                </>
-              )}
-              <Typography
-                sx={{ color: "rgba(255,255,255,0.3)", fontSize: "14px" }}
-                aria-hidden="true"
-              >
-                |
-              </Typography>
-              <Typography
-                component="time"
-                dateTime={post.date}
-                sx={{
-                  fontSize: "14px",
-                  color: "rgba(255,255,255,0.5)",
-                }}
-              >
-                {formattedDate}
-              </Typography>
-              <Typography
-                sx={{ color: "rgba(255,255,255,0.3)", fontSize: "14px" }}
-                aria-hidden="true"
-              >
-                |
-              </Typography>
-              <Typography
-                sx={{
-                  fontSize: "14px",
-                  color: "rgba(255,255,255,0.5)",
-                }}
-              >
-                {post.readingTime}
-              </Typography>
-            </Box>
-          </motion.div>
+                <Typography
+                  sx={{ ...META_SX, fontWeight: 700, color: NB_COLORS.ink }}
+                >
+                  {post.author.name}
+                </Typography>
+                {post.author.role && (
+                  <>
+                    <Typography sx={META_SX} aria-hidden="true">
+                      ·
+                    </Typography>
+                    <Typography sx={META_SX}>{post.author.role}</Typography>
+                  </>
+                )}
+                <Typography sx={META_SX} aria-hidden="true">
+                  ·
+                </Typography>
+                <Typography component="time" dateTime={post.date} sx={META_SX}>
+                  {formattedDate}
+                </Typography>
+                <Typography sx={META_SX} aria-hidden="true">
+                  ·
+                </Typography>
+                <Typography sx={META_SX}>{post.readingTime}</Typography>
+              </Box>
+            </motion.div>
+          </Box>
         </Box>
 
-        {/* Featured Image */}
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.15, duration: 0.6 }}
+        {/* Featured image band */}
+        <Box
+          sx={{
+            borderBottom: NB_RULE,
+            px: { xs: 3, md: 6 },
+            py: { xs: 4, md: 6 },
+          }}
         >
+          <Box sx={{ maxWidth: 800, mx: "auto" }}>
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.15, duration: 0.6 }}
+            >
+              <Box
+                sx={{
+                  position: "relative",
+                  width: "100%",
+                  height: { xs: 220, sm: 300, md: 400 },
+                  border: NB_RULE,
+                  boxShadow: nbShadow(),
+                  bgcolor: NB_COLORS.well,
+                }}
+              >
+                <Image
+                  src={post.image.url}
+                  alt={post.image.alt}
+                  fill
+                  style={{ objectFit: "cover" }}
+                  sizes="(max-width: 800px) 100vw, 800px"
+                  priority
+                />
+              </Box>
+            </motion.div>
+          </Box>
+        </Box>
+
+        {/* Photo gallery band */}
+        {post.gallery && post.gallery.length > 0 && (
           <Box
             sx={{
-              position: "relative",
-              width: "100%",
-              height: { xs: 220, sm: 300, md: 400 },
-              borderRadius: 3,
-              overflow: "hidden",
-              mb: { xs: 4, md: 5 },
-              bgcolor: "rgba(255,255,255,0.05)",
+              borderBottom: NB_RULE,
+              px: { xs: 3, md: 6 },
+              py: { xs: 3, md: 4 },
             }}
           >
-            <Image
-              src={post.image.url}
-              alt={post.image.alt}
-              fill
-              style={{ objectFit: "cover" }}
-              sizes="(max-width: 800px) 100vw, 800px"
-              priority
-            />
-          </Box>
-        </motion.div>
-
-        {/* Photo Gallery */}
-        {post.gallery && post.gallery.length > 0 && (
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.2, duration: 0.6 }}
-          >
-            <Box
-              sx={{
-                mb: { xs: 4, md: 5 },
-                borderRadius: 3,
-                overflow: "hidden",
-              }}
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.2, duration: 0.6 }}
             >
+              <Typography sx={{ ...META_SX, mb: 2 }}>
+                GALLERY · {String(post.gallery.length).padStart(2, "0")} FIGURES
+              </Typography>
               <Swiper
                 modules={[Autoplay]}
                 autoplay={{ delay: 3500, disableOnInteraction: false }}
@@ -275,9 +256,8 @@ export default function BlogPostContent({ slug }: { slug: string }) {
                         position: "relative",
                         width: "100%",
                         height: { xs: 220, sm: 280, md: 340 },
-                        borderRadius: 3,
-                        overflow: "hidden",
-                        bgcolor: "rgba(255,255,255,0.05)",
+                        border: NB_RULE,
+                        bgcolor: NB_COLORS.well,
                       }}
                     >
                       <Image
@@ -291,192 +271,223 @@ export default function BlogPostContent({ slug }: { slug: string }) {
                   </SwiperSlide>
                 ))}
               </Swiper>
-            </Box>
-          </motion.div>
+            </motion.div>
+          </Box>
         )}
 
-        {/* Post Body */}
-        <motion.section
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.3, duration: 0.6 }}
+        {/* Post body band */}
+        <Box
+          sx={{
+            borderBottom: NB_RULE,
+            px: { xs: 3, md: 6 },
+            py: { xs: 4, md: 6 },
+          }}
         >
-          <Box
-            sx={{
-              "& p": {
-                fontSize: { xs: "16px", md: "18px" },
-                color: "rgba(255,255,255,0.85)",
-                lineHeight: 1.8,
-                mb: 3,
-              },
-              "& h2": {
-                fontSize: { xs: "22px", sm: "26px", md: "30px" },
-                fontWeight: 700,
-                color: "white",
-                mt: { xs: 5, md: 6 },
-                mb: { xs: 2, md: 3 },
-                lineHeight: 1.3,
-              },
-              "& h3": {
-                fontSize: { xs: "18px", sm: "20px", md: "24px" },
-                fontWeight: 700,
-                color: "white",
-                mt: { xs: 4, md: 5 },
-                mb: { xs: 1.5, md: 2 },
-                lineHeight: 1.3,
-              },
-              "& figure": {
-                m: 0,
-                my: { xs: 3, md: 4 },
-              },
-              "& figure img": {
-                width: "100%",
-                height: "auto",
-                borderRadius: 3,
-                display: "block",
-              },
-              "& figcaption": {
-                textAlign: "center",
-                color: "rgba(255,255,255,0.5)",
-                fontSize: "14px",
-                mt: 1,
-              },
-              "& a": {
-                color: "#E5C767",
-                textDecoration: "underline",
-                textUnderlineOffset: "3px",
-                "&:hover": {
-                  opacity: 0.8,
-                },
-              },
-              "& ul, & ol": {
-                pl: { xs: 2.5, md: 3.5 },
-                mb: 3,
-                "& li": {
-                  fontSize: { xs: "16px", md: "18px" },
-                  color: "rgba(255,255,255,0.85)",
-                  lineHeight: 1.8,
-                  mb: 1,
-                  "&::marker": { color: "#E5C767" },
-                },
-              },
-            }}
-            dangerouslySetInnerHTML={{ __html: post.content }}
-          />
-        </motion.section>
-
-        {/* Tags */}
-        <motion.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ delay: 0.45, duration: 0.6 }}
-        >
-          <Box
-            sx={{
-              display: "flex",
-              flexWrap: "wrap",
-              gap: 1,
-              mt: { xs: 4, md: 5 },
-              pt: { xs: 3, md: 4 },
-              borderTop: "1px solid rgba(255,255,255,0.1)",
-            }}
+          <motion.section
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.3, duration: 0.6 }}
           >
-            {post.tags.map((tag) => (
-              <Box
-                key={tag}
+            <Box
+              sx={{
+                maxWidth: 760,
+                mx: "auto",
+                "& p": {
+                  fontSize: { xs: 16, md: 18 },
+                  color: NB_COLORS.ink,
+                  lineHeight: 1.8,
+                  mb: 3,
+                },
+                "& h2": {
+                  fontFamily: FONT_DISPLAY,
+                  textTransform: "uppercase",
+                  fontWeight: 400,
+                  letterSpacing: "0.01em",
+                  fontSize: { xs: 22, sm: 26, md: 30 },
+                  color: NB_COLORS.ink,
+                  lineHeight: 1.1,
+                  mt: { xs: 5, md: 6 },
+                  mb: { xs: 2, md: 3 },
+                },
+                "& h3": {
+                  fontFamily: FONT_DISPLAY,
+                  textTransform: "uppercase",
+                  fontWeight: 400,
+                  letterSpacing: "0.01em",
+                  fontSize: { xs: 18, sm: 20, md: 22 },
+                  color: NB_COLORS.ink,
+                  lineHeight: 1.15,
+                  mt: { xs: 4, md: 5 },
+                  mb: { xs: 1.5, md: 2 },
+                },
+                "& figure": {
+                  m: 0,
+                  my: { xs: 3, md: 4 },
+                },
+                "& img": {
+                  width: "100%",
+                  height: "auto",
+                  border: NB_RULE,
+                  borderRadius: 0,
+                  display: "block",
+                },
+                "& figcaption": {
+                  fontFamily: FONT_MONO,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.08em",
+                  color: NB_COLORS.steel,
+                  fontSize: 12,
+                  mt: 1.5,
+                },
+                "& a": {
+                  color: NB_COLORS.ink,
+                  textDecoration: "underline",
+                  textDecorationThickness: "2px",
+                  textUnderlineOffset: "3px",
+                  "&:hover": {
+                    bgcolor: NB_COLORS.ink,
+                    color: NB_COLORS.paperOnInk,
+                  },
+                },
+                "& strong": {
+                  color: NB_COLORS.ink,
+                },
+                "& blockquote": {
+                  m: 0,
+                  my: { xs: 3, md: 4 },
+                  px: { xs: 2.5, md: 3 },
+                  py: { xs: 2, md: 2.5 },
+                  borderLeft: NB_RULE,
+                  bgcolor: NB_COLORS.silverLight,
+                  "& p:last-of-type": { mb: 0 },
+                },
+                "& code": {
+                  fontFamily: FONT_MONO,
+                  fontSize: "0.9em",
+                  bgcolor: NB_COLORS.silverLight,
+                  px: 0.75,
+                  py: 0.25,
+                },
+                "& pre": {
+                  fontFamily: FONT_MONO,
+                  bgcolor: NB_COLORS.surface,
+                  border: NB_RULE,
+                  p: 2,
+                  overflowX: "auto",
+                  mb: 3,
+                },
+                "& hr": {
+                  border: "none",
+                  borderTop: NB_RULE,
+                  my: { xs: 4, md: 5 },
+                },
+                "& ul, & ol": {
+                  pl: { xs: 2.5, md: 3.5 },
+                  mb: 3,
+                  "& li": {
+                    fontSize: { xs: 16, md: 18 },
+                    color: NB_COLORS.ink,
+                    lineHeight: 1.8,
+                    mb: 1,
+                    "&::marker": { color: NB_COLORS.steel },
+                  },
+                },
+              }}
+              dangerouslySetInnerHTML={{ __html: post.content }}
+            />
+          </motion.section>
+        </Box>
+
+        {/* Tags + back link band */}
+        <Box
+          sx={{
+            borderBottom: NB_RULE,
+            px: { xs: 3, md: 6 },
+            py: { xs: 3, md: 4 },
+          }}
+        >
+          <Box sx={{ maxWidth: 760, mx: "auto" }}>
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={{ delay: 0.45, duration: 0.6 }}
+            >
+              <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
+                {post.tags.map((tag) => (
+                  <Box key={tag} sx={{ ...NB_TAG_SX, fontSize: 11 }}>
+                    {tag}
+                  </Box>
+                ))}
+              </Box>
+
+              <Box sx={{ mt: { xs: 3, md: 4 } }}>
+                <Box
+                  component={Link}
+                  href="/blog"
+                  sx={{
+                    ...NB_MONO_SX,
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: 1,
+                    fontSize: 13,
+                    fontWeight: 700,
+                    color: NB_COLORS.ink,
+                    textDecoration: "none",
+                    "&:hover": {
+                      bgcolor: NB_COLORS.ink,
+                      color: NB_COLORS.paperOnInk,
+                    },
+                  }}
+                >
+                  <ArrowBackIcon sx={{ fontSize: 18, color: "inherit" }} />
+                  Back to all posts
+                </Box>
+              </Box>
+            </motion.div>
+          </Box>
+        </Box>
+
+        {/* Contact CTA band */}
+        <Box
+          component="section"
+          sx={{ px: { xs: 3, md: 6 }, py: { xs: 5, md: 8 } }}
+        >
+          <Box sx={{ maxWidth: 760, mx: "auto" }}>
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.6, duration: 0.6 }}
+            >
+              <Typography sx={{ ...META_SX, mb: 2 }}>
+                PROJECT INTAKE · FORM A
+              </Typography>
+              <Typography
+                variant="h2"
+                component="h2"
                 sx={{
-                  px: 2,
-                  py: 0.5,
-                  borderRadius: 2,
-                  bgcolor: "rgba(255,255,255,0.06)",
-                  border: "1px solid rgba(255,255,255,0.1)",
-                  fontSize: "13px",
-                  color: "rgba(255,255,255,0.6)",
+                  ...NB_DISPLAY_SX,
+                  fontSize: { xs: 30, sm: 40, md: 48 },
+                  color: NB_COLORS.ink,
+                  mb: 1.5,
                 }}
               >
-                {tag}
-              </Box>
-            ))}
-          </Box>
-        </motion.div>
-
-        {/* Back to Blog */}
-        <motion.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ delay: 0.5, duration: 0.6 }}
-        >
-          <Box sx={{ mt: { xs: 5, md: 6 } }}>
-            <Link
-              href="/blog"
-              style={{
-                textDecoration: "none",
-                display: "inline-flex",
-                alignItems: "center",
-                gap: "8px",
-              }}
-            >
-              <ArrowBackIcon
-                sx={{ fontSize: 18, color: "#E5C767" }}
-              />
+                Need Our Services?
+              </Typography>
               <Typography
                 sx={{
-                  fontSize: "15px",
-                  fontWeight: 600,
-                  color: "#E5C767",
-                  "&:hover": { textDecoration: "underline" },
+                  fontSize: { xs: 15, md: 17 },
+                  color: NB_COLORS.steel,
+                  mb: { xs: 3, md: 4 },
+                  maxWidth: 520,
                 }}
               >
-                Back to all posts
+                Tell us about your project and let&apos;s build something
+                together.
               </Typography>
-            </Link>
+              <ContactForm />
+            </motion.div>
           </Box>
-        </motion.div>
-
-        {/* Contact CTA */}
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.6, duration: 0.6 }}
-        >
-          <Box
-            sx={{
-              mt: { xs: 6, md: 8 },
-              pt: { xs: 5, md: 6 },
-              borderTop: "1px solid rgba(255,255,255,0.1)",
-              display: "flex",
-              flexDirection: "column",
-              alignItems: "center",
-            }}
-          >
-            <Typography
-              variant="h2"
-              component="h2"
-              sx={{
-                fontSize: { xs: "28px", sm: "36px", md: "44px" },
-                fontWeight: 800,
-                color: "white",
-                textAlign: "center",
-                mb: 1.5,
-              }}
-            >
-              Need Our Services?
-            </Typography>
-            <Typography
-              sx={{
-                fontSize: { xs: "16px", md: "18px" },
-                color: "rgba(255,255,255,0.6)",
-                textAlign: "center",
-                mb: { xs: 3, md: 4 },
-                maxWidth: 500,
-              }}
-            >
-              Tell us about your project and let&apos;s build something
-              together.
-            </Typography>
-            <ContactForm />
-          </Box>
-        </motion.div>
+        </Box>
       </Box>
     </Box>
   );

--- a/app/brand-activations/BrandActivationForm.tsx
+++ b/app/brand-activations/BrandActivationForm.tsx
@@ -14,7 +14,16 @@ import {
 } from "@mui/material";
 import ReCAPTCHA from "react-google-recaptcha";
 import { trackGenerateLead } from "@/lib/analytics";
-import { BRAND_GRADIENT_BUTTON_SX } from "@/lib/theme";
+import {
+  FONT_MONO,
+  NB_BUTTON_SX,
+  NB_COLORS,
+  NB_DISPLAY_SX,
+  NB_MONO_SX,
+  NB_OUTLINE_TEXT_SX,
+  NB_RULE,
+  nbShadow,
+} from "@/lib/theme";
 
 const BUDGET_RANGES = [
   "$10K – $25K",
@@ -23,17 +32,41 @@ const BUDGET_RANGES = [
   "$100K+",
 ];
 
-const inputStyles = {
-  "& .MuiInputBase-root": { bgcolor: "white", color: "black" },
+const FIELD_SX = {
+  "& .MuiInputBase-root": {
+    bgcolor: NB_COLORS.surface,
+    color: NB_COLORS.ink,
+    borderRadius: 0,
+  },
+  "& .MuiOutlinedInput-notchedOutline": {
+    border: NB_RULE,
+  },
+  "& .MuiInputBase-root:hover .MuiOutlinedInput-notchedOutline": {
+    border: NB_RULE,
+  },
+  "& .MuiInputBase-root.Mui-focused .MuiOutlinedInput-notchedOutline": {
+    border: NB_RULE,
+  },
+  "& .MuiInputBase-root.Mui-focused": {
+    boxShadow: nbShadow(4),
+  },
   "& .MuiInputBase-input::placeholder": {
-    color: "rgba(0,0,0,0.7)",
+    fontFamily: FONT_MONO,
+    fontSize: 13,
+    letterSpacing: "0.08em",
+    color: NB_COLORS.steel,
     opacity: 1,
   },
-  "& .MuiInputLabel-root": { color: "rgba(0,0,0,0.7)" },
-  "& .MuiOutlinedInput-notchedOutline": {
-    borderColor: "rgba(0,0,0,0.23)",
+  "& .MuiSvgIcon-root": {
+    color: NB_COLORS.ink,
   },
-};
+} as const;
+
+const DETAILS = [
+  { label: "TYPICAL RANGE", value: "$10K TO $100K+" },
+  { label: "FASTEST TURNAROUND", value: "2 WEEKS BRIEF TO INSTALL" },
+  { label: "RESPONSE TIME", value: "WITHIN 48 HOURS" },
+];
 
 export default function BrandActivationForm() {
   const recaptchaRef = useRef<ReCAPTCHA>(null);
@@ -45,233 +78,303 @@ export default function BrandActivationForm() {
   };
 
   return (
-    <Box
-      id="inquiry"
-      sx={{
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        px: { xs: 3, md: 8 },
-        py: { xs: 6, md: 10 },
-        bgcolor: "black",
-        color: "white",
-      }}
-    >
-      <Typography
-        variant="h2"
-        component="h2"
-        sx={{
-          fontSize: { xs: "36px", md: "56px", lg: "64px" },
-          fontWeight: "bold",
-          mb: 1,
-          textAlign: "center",
-          color: "white",
-        }}
-      >
-        REQUEST A PROJECT QUOTE
-      </Typography>
-      <Typography
-        sx={{
-          fontSize: { xs: "16px", md: "20px" },
-          textAlign: "center",
-          maxWidth: 720,
-          mb: 4,
-          color: "rgba(255,255,255,0.85)",
-        }}
-      >
-        Tell us about your brief. We reply within 48 hours with next steps.
-      </Typography>
-
+    <Box component="section" id="inquiry" sx={{ bgcolor: NB_COLORS.paper }}>
       <Box
-        component="form"
         sx={{
-          display: "flex",
-          flexDirection: "column",
-          width: "100%",
-          maxWidth: 780,
-          gap: { xs: 2, md: 2.5 },
-        }}
-        onSubmit={async (e: FormEvent<HTMLFormElement>) => {
-          e.preventDefault();
-
-          const captchaValue = recaptchaRef.current?.getValue();
-          if (!captchaValue) {
-            alert("Please complete the CAPTCHA");
-            return;
-          }
-          if (!budgetRange) {
-            alert("Please select a budget range");
-            return;
-          }
-
-          const form = e.currentTarget;
-          const formElements = form.elements as HTMLFormControlsCollection & {
-            name: HTMLInputElement;
-            email: HTMLInputElement;
-            company: HTMLInputElement;
-            projectDate: HTMLInputElement;
-            referral: HTMLInputElement;
-            brief: HTMLTextAreaElement;
-          };
-
-          const formData = {
-            recaptchaToken: captchaValue,
-            name: formElements.name.value,
-            email: formElements.email.value,
-            company: formElements.company.value,
-            projectDate: formElements.projectDate.value,
-            budgetRange,
-            referral: formElements.referral.value,
-            brief: formElements.brief.value,
-            formType: "brandActivation",
-          };
-
-          setSubmitting(true);
-          try {
-            const response = await fetch("/api/contact", {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify(formData),
-            });
-
-            if (response.ok) {
-              trackGenerateLead({ form: "brandActivation", value: 500 });
-              alert("Thank you. Your inquiry is in. We reply within 48 hours.");
-              form.reset();
-              setBudgetRange("");
-              recaptchaRef.current?.reset();
-            } else {
-              throw new Error("Failed to send inquiry");
-            }
-          } catch {
-            alert("An error occurred. Please try again.");
-          } finally {
-            setSubmitting(false);
-          }
+          display: "grid",
+          gridTemplateColumns: { xs: "1fr", md: "5fr 7fr" },
         }}
       >
-        <TextField
-          name="name"
-          placeholder="NAME"
-          required
-          fullWidth
-          inputProps={{ "aria-label": "Name" }}
-          sx={inputStyles}
-        />
-        <TextField
-          name="email"
-          type="email"
-          placeholder="EMAIL"
-          required
-          fullWidth
-          inputProps={{ "aria-label": "Email" }}
-          sx={inputStyles}
-        />
-        <TextField
-          name="company"
-          placeholder="COMPANY / AGENCY"
-          required
-          fullWidth
-          inputProps={{ "aria-label": "Company" }}
-          sx={inputStyles}
-        />
-        <Box>
+        {/* Left: intake header */}
+        <Box
+          sx={{
+            px: { xs: 3, md: 6 },
+            py: { xs: 4, md: 6 },
+            borderRight: { md: NB_RULE },
+            borderBottom: { xs: NB_RULE, md: "none" },
+            display: "flex",
+            flexDirection: "column",
+          }}
+        >
+          <Typography sx={{ ...NB_MONO_SX, fontSize: 12, color: NB_COLORS.steel, mb: 2 }}>
+            PROJECT INTAKE · BRAND ACTIVATIONS
+          </Typography>
           <Typography
-            component="label"
-            htmlFor="projectDate"
+            variant="h2"
             sx={{
-              display: "block",
-              fontSize: "12px",
-              fontWeight: 700,
-              letterSpacing: "0.1em",
-              color: "rgba(255,255,255,0.7)",
-              mb: 0.75,
+              ...NB_DISPLAY_SX,
+              fontSize: { xs: 36, sm: 48, lg: 60 },
+              color: NB_COLORS.ink,
+              mb: 1,
             }}
           >
-            ESTIMATED PROJECT DATE
+            REQUEST A
           </Typography>
-          <TextField
-            id="projectDate"
-            name="projectDate"
-            type="date"
-            required
-            fullWidth
-            inputProps={{ "aria-label": "Estimated Project Date" }}
-            sx={inputStyles}
-          />
-        </Box>
-        <FormControl
-          fullWidth
-          sx={{
-            "& .MuiInputBase-root": { bgcolor: "white", color: "black" },
-            "& .MuiInputLabel-root": { color: "rgba(0,0,0,0.7)" },
-            "& .MuiInputLabel-root.Mui-focused": { color: "black" },
-            "& .MuiSelect-select": { color: "black" },
-          }}
-        >
-          <InputLabel id="budget-label">BUDGET RANGE</InputLabel>
-          <Select
-            labelId="budget-label"
-            value={budgetRange}
-            onChange={handleBudgetChange}
-            label="BUDGET RANGE"
-            required
-            inputProps={{ "aria-label": "Budget Range" }}
+          <Typography
+            sx={{
+              ...NB_OUTLINE_TEXT_SX,
+              fontSize: { xs: 36, sm: 48, lg: 60 },
+              mb: 3,
+            }}
           >
-            {BUDGET_RANGES.map((range) => (
-              <MenuItem key={range} value={range}>
-                {range}
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
-        <TextField
-          name="referral"
-          placeholder="HOW DID YOU HEAR ABOUT US?"
-          fullWidth
-          inputProps={{ "aria-label": "How did you hear about us" }}
-          sx={inputStyles}
-        />
-        <TextField
-          name="brief"
-          placeholder="TELL US ABOUT THE PROJECT"
-          required
-          fullWidth
-          multiline
-          minRows={5}
-          inputProps={{ "aria-label": "Brief" }}
-          sx={inputStyles}
-        />
+            PROJECT QUOTE.
+          </Typography>
+          <Typography
+            sx={{ fontSize: { xs: 15, md: 17 }, color: NB_COLORS.ink, maxWidth: 420, mb: 4 }}
+          >
+            Tell us about your brief. We reply within 48 hours with next steps.
+          </Typography>
 
-        <Box sx={{ mb: 1, display: "flex", justifyContent: "center" }}>
-          <ReCAPTCHA
-            ref={recaptchaRef}
-            sitekey={process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY || ""}
-          />
+          <Box sx={{ mt: "auto" }}>
+            {DETAILS.map((row) => (
+              <Box
+                key={row.label}
+                sx={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  gap: 2,
+                  py: 1.25,
+                  borderTop: NB_RULE,
+                }}
+              >
+                <Typography sx={{ ...NB_MONO_SX, fontSize: 11, color: NB_COLORS.steel }}>
+                  {row.label}
+                </Typography>
+                <Typography
+                  sx={{ ...NB_MONO_SX, fontSize: 11, fontWeight: 700, color: NB_COLORS.ink }}
+                >
+                  {row.value}
+                </Typography>
+              </Box>
+            ))}
+          </Box>
         </Box>
 
-        <Button
-          type="submit"
-          variant="contained"
-          disabled={submitting}
-          sx={{
-            alignSelf: "center",
-            px: 4,
-            py: 1.75,
-            width: "100%",
-            maxWidth: 780,
-            fontWeight: 700,
-            fontSize: "16px",
-            letterSpacing: "0.05em",
-            ...BRAND_GRADIENT_BUTTON_SX,
-            "&.Mui-disabled": {
-              background: "rgba(229,199,103,0.4)",
-              color: "white",
-            },
-          }}
-        >
-          {submitting ? "SENDING..." : "REQUEST A QUOTE"}
-        </Button>
+        {/* Right: form */}
+        <Box sx={{ px: { xs: 3, md: 6 }, py: { xs: 4, md: 6 } }}>
+          <Box
+            component="form"
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              width: "100%",
+              maxWidth: 780,
+              gap: { xs: 2, md: 2.5 },
+            }}
+            onSubmit={async (e: FormEvent<HTMLFormElement>) => {
+              e.preventDefault();
+
+              const captchaValue = recaptchaRef.current?.getValue();
+              if (!captchaValue) {
+                alert("Please complete the CAPTCHA");
+                return;
+              }
+              if (!budgetRange) {
+                alert("Please select a budget range");
+                return;
+              }
+
+              const form = e.currentTarget;
+              const formElements = form.elements as HTMLFormControlsCollection & {
+                name: HTMLInputElement;
+                email: HTMLInputElement;
+                company: HTMLInputElement;
+                projectDate: HTMLInputElement;
+                referral: HTMLInputElement;
+                brief: HTMLTextAreaElement;
+              };
+
+              const formData = {
+                recaptchaToken: captchaValue,
+                name: formElements.name.value,
+                email: formElements.email.value,
+                company: formElements.company.value,
+                projectDate: formElements.projectDate.value,
+                budgetRange,
+                referral: formElements.referral.value,
+                brief: formElements.brief.value,
+                formType: "brandActivation",
+              };
+
+              setSubmitting(true);
+              try {
+                const response = await fetch("/api/contact", {
+                  method: "POST",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify(formData),
+                });
+
+                if (response.ok) {
+                  trackGenerateLead({ form: "brandActivation", value: 500 });
+                  alert("Thank you. Your inquiry is in. We reply within 48 hours.");
+                  form.reset();
+                  setBudgetRange("");
+                  recaptchaRef.current?.reset();
+                } else {
+                  throw new Error("Failed to send inquiry");
+                }
+              } catch {
+                alert("An error occurred. Please try again.");
+              } finally {
+                setSubmitting(false);
+              }
+            }}
+          >
+            <TextField
+              name="name"
+              placeholder="NAME"
+              required
+              fullWidth
+              inputProps={{ "aria-label": "Name" }}
+              sx={FIELD_SX}
+            />
+            <TextField
+              name="email"
+              type="email"
+              placeholder="EMAIL"
+              required
+              fullWidth
+              inputProps={{ "aria-label": "Email" }}
+              sx={FIELD_SX}
+            />
+            <TextField
+              name="company"
+              placeholder="COMPANY / AGENCY"
+              required
+              fullWidth
+              inputProps={{ "aria-label": "Company" }}
+              sx={FIELD_SX}
+            />
+            <Box>
+              <Typography
+                component="label"
+                htmlFor="projectDate"
+                sx={{
+                  ...NB_MONO_SX,
+                  display: "block",
+                  fontSize: 12,
+                  fontWeight: 700,
+                  color: NB_COLORS.steel,
+                  mb: 0.75,
+                }}
+              >
+                ESTIMATED PROJECT DATE
+              </Typography>
+              <TextField
+                id="projectDate"
+                name="projectDate"
+                type="date"
+                required
+                fullWidth
+                inputProps={{ "aria-label": "Estimated Project Date" }}
+                sx={FIELD_SX}
+              />
+            </Box>
+            <FormControl
+              fullWidth
+              sx={{
+                ...FIELD_SX,
+                "& .MuiInputLabel-root": {
+                  fontFamily: FONT_MONO,
+                  fontSize: 13,
+                  letterSpacing: "0.08em",
+                  color: NB_COLORS.steel,
+                },
+                "& .MuiInputLabel-root.Mui-focused": {
+                  color: NB_COLORS.ink,
+                },
+              }}
+            >
+              <InputLabel id="budget-label">BUDGET RANGE</InputLabel>
+              <Select
+                labelId="budget-label"
+                value={budgetRange}
+                onChange={handleBudgetChange}
+                label="BUDGET RANGE"
+                required
+                inputProps={{ "aria-label": "Budget Range" }}
+                MenuProps={{
+                  PaperProps: {
+                    sx: {
+                      bgcolor: NB_COLORS.surface,
+                      color: NB_COLORS.ink,
+                      border: NB_RULE,
+                      borderRadius: 0,
+                      boxShadow: nbShadow(4),
+                      "& .MuiMenuItem-root": {
+                        fontFamily: FONT_MONO,
+                        fontSize: 13,
+                        letterSpacing: "0.08em",
+                        "&:hover": {
+                          bgcolor: NB_COLORS.ink,
+                          color: NB_COLORS.paperOnInk,
+                        },
+                        "&.Mui-selected": {
+                          bgcolor: NB_COLORS.silver,
+                          color: NB_COLORS.onSilver,
+                          "&:hover": {
+                            bgcolor: NB_COLORS.ink,
+                            color: NB_COLORS.paperOnInk,
+                          },
+                        },
+                      },
+                    },
+                  },
+                }}
+              >
+                {BUDGET_RANGES.map((range) => (
+                  <MenuItem key={range} value={range}>
+                    {range}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <TextField
+              name="referral"
+              placeholder="HOW DID YOU HEAR ABOUT US?"
+              fullWidth
+              inputProps={{ "aria-label": "How did you hear about us" }}
+              sx={FIELD_SX}
+            />
+            <TextField
+              name="brief"
+              placeholder="TELL US ABOUT THE PROJECT"
+              required
+              fullWidth
+              multiline
+              minRows={5}
+              inputProps={{ "aria-label": "Brief" }}
+              sx={FIELD_SX}
+            />
+
+            <Box sx={{ display: "flex", justifyContent: { xs: "center", md: "flex-start" } }}>
+              <ReCAPTCHA
+                ref={recaptchaRef}
+                sitekey={process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY || ""}
+              />
+            </Box>
+
+            <Button
+              type="submit"
+              disableElevation
+              disabled={submitting}
+              sx={{
+                ...NB_BUTTON_SX,
+                width: "100%",
+                py: 1.75,
+                fontSize: 14,
+                "&.Mui-disabled": {
+                  bgcolor: NB_COLORS.silverLight,
+                  color: NB_COLORS.steel,
+                  border: NB_RULE,
+                  boxShadow: nbShadow(0),
+                },
+              }}
+            >
+              {submitting ? "SENDING..." : "REQUEST A QUOTE"}
+            </Button>
+          </Box>
+        </Box>
       </Box>
     </Box>
   );

--- a/app/brand-activations/BrandActivationsFAQ.tsx
+++ b/app/brand-activations/BrandActivationsFAQ.tsx
@@ -1,14 +1,15 @@
 "use client";
 
+import { useState } from "react";
+import { Box, ButtonBase, Collapse, Typography } from "@mui/material";
+import AddIcon from "@mui/icons-material/Add";
+import RemoveIcon from "@mui/icons-material/Remove";
 import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  Box,
-  Typography,
-} from "@mui/material";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import { BRAND_GRADIENT_TEXT_SX } from "@/lib/theme";
+  NB_COLORS,
+  NB_DISPLAY_SX,
+  NB_MONO_SX,
+  NB_RULE,
+} from "@/lib/theme";
 
 // TODO: refine copy with founder-voice answers. Draft answers below are
 // placeholders that reflect the Ads plan's positioning (2 week turnaround,
@@ -33,80 +34,145 @@ const FAQS = [
 ];
 
 export default function BrandActivationsFAQ() {
+  const [openIndex, setOpenIndex] = useState<number | null>(null);
+
   return (
     <Box
-      sx={{
-        bgcolor: "black",
-        color: "white",
-        px: { xs: 3, md: 8 },
-        py: { xs: 8, md: 12 },
-      }}
+      component="section"
+      sx={{ bgcolor: NB_COLORS.paper, borderBottom: NB_RULE }}
     >
-      <Box sx={{ maxWidth: 900, mx: "auto" }}>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "baseline",
+          justifyContent: "space-between",
+          px: { xs: 3, md: 6 },
+          py: { xs: 3, md: 4 },
+          borderBottom: NB_RULE,
+          flexWrap: "wrap",
+          gap: 1,
+        }}
+      >
         <Typography
           variant="h2"
-          component="h2"
           sx={{
-            fontSize: { xs: "32px", md: "50px", lg: "60px" },
-            fontWeight: "bold",
-            textAlign: "center",
-            mb: { xs: 4, md: 6 },
+            ...NB_DISPLAY_SX,
+            fontSize: { xs: 32, sm: 48, lg: 64 },
+            color: NB_COLORS.ink,
           }}
         >
-          <Box component="span" sx={{ color: "white" }}>
-            COMMONLY{" "}
-          </Box>
-          <Box component="span" sx={BRAND_GRADIENT_TEXT_SX}>
-            ASKED
-          </Box>
+          COMMONLY ASKED
         </Typography>
+        <Typography sx={{ ...NB_MONO_SX, fontSize: 12, color: NB_COLORS.steel }}>
+          FAQ INDEX · 04 ENTRIES
+        </Typography>
+      </Box>
 
-        <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
-          {FAQS.map((item, i) => (
-            <Accordion
-              key={i}
-              disableGutters
+      {FAQS.map((item, i) => {
+        const open = openIndex === i;
+        return (
+          <Box
+            key={item.q}
+            sx={{ borderBottom: i < FAQS.length - 1 ? NB_RULE : "none" }}
+          >
+            <ButtonBase
+              onClick={() => setOpenIndex(open ? null : i)}
+              aria-expanded={open}
+              aria-controls={`faq-answer-${i}`}
               sx={{
-                bgcolor: "rgba(255,255,255,0.04)",
-                color: "white",
-                border: "1px solid rgba(229,199,103,0.2)",
-                borderRadius: "12px !important",
-                "&:before": { display: "none" },
-                overflow: "hidden",
+                width: "100%",
+                display: "grid",
+                gridTemplateColumns: { xs: "auto 1fr auto", md: "80px 1fr auto" },
+                alignItems: "center",
+                textAlign: "left",
+                gap: { xs: 2, md: 3 },
+                px: { xs: 3, md: 6 },
+                py: { xs: 2, md: 2.5 },
+                borderRadius: 0,
+                color: NB_COLORS.ink,
+                bgcolor: open ? NB_COLORS.ink : "transparent",
+                ...(open && { color: NB_COLORS.paperOnInk }),
+                "&:hover": {
+                  bgcolor: NB_COLORS.ink,
+                  color: NB_COLORS.paperOnInk,
+                  "& .faq-index": { color: NB_COLORS.mutedOnInk },
+                },
+                "& .faq-index": {
+                  color: open ? NB_COLORS.mutedOnInk : NB_COLORS.steel,
+                },
               }}
             >
-              <AccordionSummary
-                expandIcon={<ExpandMoreIcon sx={{ color: "#E5C767" }} />}
+              <Typography
+                className="faq-index"
+                sx={{ ...NB_MONO_SX, fontSize: 12 }}
+              >
+                Q.{String(i + 1).padStart(2, "0")}
+              </Typography>
+              <Typography
+                component="h3"
                 sx={{
-                  px: { xs: 2, md: 3 },
-                  py: 1,
-                  "& .MuiAccordionSummary-content": { my: 2 },
+                  fontSize: { xs: 15, md: 18 },
+                  fontWeight: 600,
+                  color: "inherit",
+                }}
+              >
+                {item.q}
+              </Typography>
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  width: 32,
+                  height: 32,
+                  border: `2px solid currentColor`,
+                  flexShrink: 0,
+                }}
+              >
+                {open ? (
+                  <RemoveIcon sx={{ fontSize: 18 }} />
+                ) : (
+                  <AddIcon sx={{ fontSize: 18 }} />
+                )}
+              </Box>
+            </ButtonBase>
+
+            <Collapse in={open} id={`faq-answer-${i}`}>
+              <Box
+                sx={{
+                  px: { xs: 3, md: 6 },
+                  py: { xs: 2.5, md: 3 },
+                  borderTop: NB_RULE,
+                  display: "grid",
+                  gridTemplateColumns: { xs: "1fr", md: "80px 1fr" },
+                  gap: { xs: 0, md: 3 },
                 }}
               >
                 <Typography
                   sx={{
-                    fontSize: { xs: "16px", md: "18px" },
-                    fontWeight: 600,
+                    ...NB_MONO_SX,
+                    fontSize: 12,
+                    color: NB_COLORS.steel,
+                    display: { xs: "none", md: "block" },
                   }}
                 >
-                  {item.q}
+                  A.{String(i + 1).padStart(2, "0")}
                 </Typography>
-              </AccordionSummary>
-              <AccordionDetails sx={{ px: { xs: 2, md: 3 }, pb: 3 }}>
                 <Typography
                   sx={{
-                    fontSize: { xs: "15px", md: "16px" },
-                    color: "rgba(255,255,255,0.85)",
+                    fontSize: { xs: 15, md: 16 },
+                    color: NB_COLORS.ink,
                     lineHeight: 1.6,
+                    maxWidth: 780,
                   }}
                 >
                   {item.a}
                 </Typography>
-              </AccordionDetails>
-            </Accordion>
-          ))}
-        </Box>
-      </Box>
+              </Box>
+            </Collapse>
+          </Box>
+        );
+      })}
     </Box>
   );
 }

--- a/app/brand-activations/BrandActivationsHero.tsx
+++ b/app/brand-activations/BrandActivationsHero.tsx
@@ -3,7 +3,17 @@
 import { Box, Button, Typography } from "@mui/material";
 import Image from "next/image";
 import { motion } from "framer-motion";
-import { BRAND_GRADIENT_BUTTON_SX, BRAND_GRADIENT_TEXT_SX } from "@/lib/theme";
+import {
+  NB_BUTTON_OUTLINE_SX,
+  NB_BUTTON_SX,
+  NB_COLORS,
+  NB_DISPLAY_SX,
+  NB_MONO_SX,
+  NB_OUTLINE_TEXT_SX,
+  NB_RULE,
+  NB_TAG_SX,
+  nbShadow,
+} from "@/lib/theme";
 
 // TODO: replace hero image with a 15s branded reel once produced
 // (use <video autoPlay muted loop playsInline> with a webm/mp4 hosted on S3).
@@ -15,186 +25,182 @@ const BADGES = ["WOMEN OWNED", "NYC + LA", "CONCEPT TO INSTALL"];
 export default function BrandActivationsHero() {
   return (
     <Box
-      sx={{
-        position: "relative",
-        minHeight: { xs: "90vh", md: "100vh" },
-        width: "100%",
-        overflow: "hidden",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        bgcolor: "black",
-        pt: { xs: "95px", md: "40px" },
-      }}
+      component="section"
+      sx={{ bgcolor: NB_COLORS.paper, borderBottom: NB_RULE }}
     >
-      <Image
-        src={HERO_IMAGE}
-        alt="DripDome brand activation installation"
-        fill
-        priority
-        sizes="100vw"
-        style={{ objectFit: "cover", opacity: 0.55 }}
-      />
       <Box
         sx={{
-          position: "absolute",
-          inset: 0,
-          background:
-            "linear-gradient(180deg, rgba(0,0,0,0.35) 0%, rgba(0,0,0,0.85) 100%)",
-        }}
-      />
-
-      <Box
-        sx={{
-          position: "relative",
-          zIndex: 1,
-          px: { xs: 3, md: 8 },
-          py: { xs: 10, md: 10, lg: 10, xl: 12 },
-          maxWidth: 1200,
-          width: "100%",
-          textAlign: "center",
+          display: "grid",
+          gridTemplateColumns: { xs: "1fr", md: "7fr 5fr" },
+          maxWidth: 1440,
+          mx: "auto",
         }}
       >
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6 }}
+        {/* Left: type column */}
+        <Box
+          sx={{
+            px: { xs: 3, md: 6 },
+            py: { xs: 5, md: 8 },
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "center",
+            borderRight: { md: NB_RULE },
+          }}
         >
-          <Box
-            sx={{
-              display: "flex",
-              flexWrap: "wrap",
-              justifyContent: "center",
-              gap: 1.5,
-              mb: 4,
-            }}
+          <motion.div
+            initial={{ opacity: 0, y: 16 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5 }}
           >
-            {BADGES.map((badge) => (
-              <Box
-                key={badge}
+            <Typography
+              sx={{ ...NB_MONO_SX, fontSize: 12, color: NB_COLORS.steel, mb: 2 }}
+            >
+              BRAND ACTIVATIONS · DESIGN + FABRICATION + INSTALL · NYC + LA
+            </Typography>
+          </motion.div>
+
+          <motion.div
+            initial={{ opacity: 0, y: 24 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.1 }}
+          >
+            <Typography
+              variant="h1"
+              component="h1"
+              sx={{
+                ...NB_DISPLAY_SX,
+                fontSize: { xs: 40, sm: 56, md: 60, lg: 76, xl: 88 },
+                color: NB_COLORS.ink,
+                mb: 3,
+              }}
+            >
+              NYC BRAND
+              <Box component="span" sx={{ display: "block" }}>
+                ACTIVATION STUDIO.
+              </Box>
+              <Box component="span" sx={{ ...NB_OUTLINE_TEXT_SX, display: "block" }}>
+                DESIGNED. BUILT. INSTALLED.
+              </Box>
+            </Typography>
+          </motion.div>
+
+          <motion.div
+            initial={{ opacity: 0, y: 16 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.25 }}
+          >
+            <Typography
+              sx={{
+                fontSize: { xs: 16, md: 18 },
+                color: NB_COLORS.ink,
+                maxWidth: 560,
+                mb: 4,
+              }}
+            >
+              From brief to install in as little as 2 weeks. Full service
+              fabrication studio trusted by Google and top lifestyle brands.
+            </Typography>
+          </motion.div>
+
+          <motion.div
+            initial={{ opacity: 0, y: 16 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.4 }}
+          >
+            <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2, mb: 4 }}>
+              <Button
+                component="a"
+                href="#inquiry"
+                disableElevation
+                sx={{ ...NB_BUTTON_SX, px: 4, py: 1.5, fontSize: { xs: 13, md: 14 } }}
+              >
+                REQUEST A QUOTE
+              </Button>
+              <Button
+                component="a"
+                href="#case-studies"
+                onClick={(e: React.MouseEvent<HTMLAnchorElement>) => {
+                  e.preventDefault();
+                  document
+                    .getElementById("case-studies")
+                    ?.scrollIntoView({ behavior: "smooth" });
+                }}
+                disableElevation
                 sx={{
-                  px: 2,
-                  py: 0.75,
-                  border: "1px solid rgba(229,199,103,0.6)",
-                  borderRadius: "999px",
-                  fontSize: { xs: "11px", md: "13px" },
-                  fontWeight: 600,
-                  letterSpacing: "0.1em",
-                  color: "white",
-                  bgcolor: "rgba(229,199,103,0.08)",
+                  ...NB_BUTTON_OUTLINE_SX,
+                  px: 4,
+                  py: 1.5,
+                  fontSize: { xs: 13, md: 14 },
                 }}
               >
-                {badge}
-              </Box>
-            ))}
-          </Box>
-        </motion.div>
-
-        <motion.div
-          initial={{ opacity: 0, y: 30 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.8, delay: 0.1 }}
-        >
-          <Typography
-            variant="h1"
-            component="h1"
-            sx={{
-              fontSize: {
-                xs: "40px",
-                sm: "56px",
-                md: "64px",
-                lg: "72px",
-                xl: "96px",
-              },
-              fontWeight: "bold",
-              lineHeight: 1.05,
-              color: "white",
-              mb: { xs: 3, lg: 2.5, xl: 3 },
-            }}
-          >
-            NYC BRAND ACTIVATION STUDIO.
-            <br />
-            <Box component="span" sx={BRAND_GRADIENT_TEXT_SX}>
-              DESIGNED. BUILT. INSTALLED.
+                SEE THE WORK
+              </Button>
             </Box>
-          </Typography>
-        </motion.div>
 
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.8, delay: 0.25 }}
-        >
-          <Typography
-            sx={{
-              fontSize: { xs: "16px", md: "18px", lg: "18px", xl: "22px" },
-              color: "rgba(255,255,255,0.9)",
-              maxWidth: 820,
-              mx: "auto",
-              mb: { xs: 4, lg: 4, xl: 5 },
-            }}
-          >
-            From brief to install in as little as 2 weeks. Full service
-            fabrication studio trusted by Google and top lifestyle brands.
-          </Typography>
-        </motion.div>
+            <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1.5 }}>
+              {BADGES.map((badge) => (
+                <Box key={badge} sx={{ ...NB_TAG_SX, fontSize: { xs: 10, md: 11 } }}>
+                  {badge}
+                </Box>
+              ))}
+            </Box>
+          </motion.div>
+        </Box>
 
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.8, delay: 0.4 }}
+        {/* Right: mounted exhibit plate */}
+        <Box
+          sx={{
+            px: { xs: 3, md: 5 },
+            py: { xs: 4, md: 8 },
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            bgcolor: { md: NB_COLORS.silverLight },
+            borderTop: { xs: NB_RULE, md: "none" },
+          }}
         >
-          <Box
-            sx={{
-              display: "flex",
-              flexWrap: "wrap",
-              justifyContent: "center",
-              gap: 2,
-            }}
+          <motion.div
+            initial={{ opacity: 0, y: 24 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.2 }}
+            style={{ width: "100%", maxWidth: 520 }}
           >
-            <Button
-              component="a"
-              href="#inquiry"
-              variant="contained"
+            <Box
               sx={{
-                px: 4,
-                py: 1.75,
-                fontSize: { xs: "14px", md: "16px" },
-                fontWeight: 700,
-                letterSpacing: "0.08em",
-                ...BRAND_GRADIENT_BUTTON_SX,
+                border: NB_RULE,
+                bgcolor: NB_COLORS.surface,
+                boxShadow: nbShadow(10),
+                p: 1,
               }}
             >
-              REQUEST A QUOTE
-            </Button>
-            <Button
-              component="a"
-              href="#case-studies"
-              onClick={(e: React.MouseEvent<HTMLAnchorElement>) => {
-                e.preventDefault();
-                document
-                  .getElementById("case-studies")
-                  ?.scrollIntoView({ behavior: "smooth" });
-              }}
-              variant="outlined"
-              sx={{
-                px: 4,
-                py: 1.75,
-                fontSize: { xs: "14px", md: "16px" },
-                fontWeight: 700,
-                letterSpacing: "0.08em",
-                color: "white",
-                borderColor: "rgba(255,255,255,0.6)",
-                "&:hover": {
-                  borderColor: "white",
-                  bgcolor: "rgba(255,255,255,0.08)",
-                },
-              }}
-            >
-              SEE THE WORK
-            </Button>
-          </Box>
-        </motion.div>
+              <Box sx={{ position: "relative", aspectRatio: "4 / 3", border: NB_RULE }}>
+                <Image
+                  src={HERO_IMAGE}
+                  alt="DripDome brand activation installation"
+                  fill
+                  priority
+                  sizes="(max-width: 900px) 90vw, 40vw"
+                  style={{ objectFit: "cover" }}
+                />
+              </Box>
+              <Box
+                sx={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  pt: 1,
+                  px: 0.5,
+                }}
+              >
+                <Typography sx={{ ...NB_MONO_SX, fontSize: 11, color: NB_COLORS.steel }}>
+                  FIG. 01 · LESGC ACTIVATION
+                </Typography>
+                <Typography sx={{ ...NB_MONO_SX, fontSize: 11, color: NB_COLORS.steel }}>
+                  INSTALLED &lt; 2 HR
+                </Typography>
+              </Box>
+            </Box>
+          </motion.div>
+        </Box>
       </Box>
     </Box>
   );

--- a/app/brand-activations/BrandActivationsProcess.tsx
+++ b/app/brand-activations/BrandActivationsProcess.tsx
@@ -1,25 +1,28 @@
 "use client";
 
 import { Box, Typography } from "@mui/material";
-import BrushIcon from "@mui/icons-material/Brush";
-import BuildIcon from "@mui/icons-material/Build";
-import LocalShippingIcon from "@mui/icons-material/LocalShipping";
 import { motion } from "framer-motion";
-import { BRAND_GRADIENT_TEXT_SX } from "@/lib/theme";
+import {
+  NB_COLORS,
+  NB_DISPLAY_SX,
+  NB_MONO_SX,
+  NB_OUTLINE_TEXT_SX,
+  NB_RULE,
+} from "@/lib/theme";
 
 const STEPS = [
   {
-    icon: BrushIcon,
+    number: "01",
     label: "DESIGN",
     desc: "Concept, renders, and brand alignment in the first week.",
   },
   {
-    icon: BuildIcon,
+    number: "02",
     label: "FABRICATION",
     desc: "Built in our NYC shop. No third party vendors, no miscommunication.",
   },
   {
-    icon: LocalShippingIcon,
+    number: "03",
     label: "INSTALL",
     desc: "Turnkey install and strike. Shot ready on day one.",
   },
@@ -28,97 +31,97 @@ const STEPS = [
 export default function BrandActivationsProcess() {
   return (
     <Box
-      sx={{
-        bgcolor: "black",
-        color: "white",
-        px: { xs: 3, md: 8 },
-        py: { xs: 8, md: 12 },
-      }}
+      component="section"
+      sx={{ bgcolor: NB_COLORS.paper, borderBottom: NB_RULE }}
     >
-      <Box sx={{ maxWidth: 1200, mx: "auto", textAlign: "center" }}>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "baseline",
+          justifyContent: "space-between",
+          px: { xs: 3, md: 6 },
+          py: { xs: 3, md: 4 },
+          borderBottom: NB_RULE,
+          flexWrap: "wrap",
+          gap: 1,
+        }}
+      >
         <Typography
           variant="h2"
-          component="h2"
           sx={{
-            fontSize: { xs: "32px", md: "50px", lg: "60px" },
-            fontWeight: "bold",
-            mb: 2,
+            ...NB_DISPLAY_SX,
+            fontSize: { xs: 32, sm: 48, lg: 64 },
+            color: NB_COLORS.ink,
           }}
         >
-          <Box component="span" sx={{ color: "white" }}>
-            EVERYTHING UNDER{" "}
-          </Box>
-          <Box component="span" sx={BRAND_GRADIENT_TEXT_SX}>
-            ONE ROOF
-          </Box>
+          EVERYTHING UNDER ONE ROOF
         </Typography>
-        <Typography
-          sx={{
-            fontSize: { xs: "16px", md: "20px" },
-            color: "rgba(255,255,255,0.8)",
-            maxWidth: 720,
-            mx: "auto",
-            mb: { xs: 6, md: 8 },
-          }}
-        >
+        <Typography sx={{ ...NB_MONO_SX, fontSize: 12, color: NB_COLORS.steel }}>
+          PROCESS · DESIGN, FAB, INSTALL
+        </Typography>
+      </Box>
+
+      <Box
+        sx={{
+          px: { xs: 3, md: 6 },
+          py: { xs: 2.5, md: 3 },
+          borderBottom: NB_RULE,
+        }}
+      >
+        <Typography sx={{ fontSize: { xs: 15, md: 17 }, color: NB_COLORS.steel, maxWidth: 720 }}>
           No handoffs between design and build. Brief to install in a single
           team.
         </Typography>
+      </Box>
 
-        <Box
-          sx={{
-            display: "grid",
-            gridTemplateColumns: { xs: "1fr", md: "repeat(3, 1fr)" },
-            gap: { xs: 4, md: 6 },
-          }}
-        >
-          {STEPS.map((step, i) => {
-            const Icon = step.icon;
-            return (
-              <motion.div
-                key={step.label}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                viewport={{ once: true }}
-                transition={{ duration: 0.5, delay: i * 0.1 }}
+      <Box
+        sx={{
+          display: "grid",
+          gridTemplateColumns: { xs: "1fr", md: "repeat(3, 1fr)" },
+        }}
+      >
+        {STEPS.map((step, i) => (
+          <motion.div
+            key={step.label}
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.5, delay: i * 0.1 }}
+            style={{ height: "100%" }}
+          >
+            <Box
+              sx={{
+                height: "100%",
+                px: { xs: 3, md: 4 },
+                py: { xs: 3, md: 5 },
+                borderRight: { md: i < STEPS.length - 1 ? NB_RULE : "none" },
+                borderBottom: {
+                  xs: i < STEPS.length - 1 ? NB_RULE : "none",
+                  md: "none",
+                },
+              }}
+            >
+              <Typography
+                sx={{ ...NB_OUTLINE_TEXT_SX, fontSize: { xs: 64, md: 96 }, mb: 2 }}
               >
-                <Box
-                  sx={{
-                    p: { xs: 3, md: 4 },
-                    border: "1px solid rgba(229,199,103,0.2)",
-                    borderRadius: 3,
-                    bgcolor: "rgba(229,199,103,0.04)",
-                    height: "100%",
-                    display: "flex",
-                    flexDirection: "column",
-                    alignItems: "center",
-                    textAlign: "center",
-                  }}
-                >
-                  <Icon sx={{ fontSize: 48, color: "#E5C767", mb: 2 }} />
-                  <Typography
-                    sx={{
-                      fontSize: { xs: "20px", md: "24px" },
-                      fontWeight: 700,
-                      letterSpacing: "0.05em",
-                      mb: 1.5,
-                    }}
-                  >
-                    {step.label}
-                  </Typography>
-                  <Typography
-                    sx={{
-                      fontSize: { xs: "15px", md: "16px" },
-                      color: "rgba(255,255,255,0.8)",
-                    }}
-                  >
-                    {step.desc}
-                  </Typography>
-                </Box>
-              </motion.div>
-            );
-          })}
-        </Box>
+                {step.number}
+              </Typography>
+              <Typography
+                sx={{
+                  ...NB_DISPLAY_SX,
+                  fontSize: { xs: 18, md: 22 },
+                  color: NB_COLORS.ink,
+                  mb: 1.5,
+                }}
+              >
+                {step.label}
+              </Typography>
+              <Typography sx={{ fontSize: { xs: 14, md: 16 }, color: NB_COLORS.steel }}>
+                {step.desc}
+              </Typography>
+            </Box>
+          </motion.div>
+        ))}
       </Box>
     </Box>
   );

--- a/app/brand-activations/CaseStudiesSection.tsx
+++ b/app/brand-activations/CaseStudiesSection.tsx
@@ -1,10 +1,15 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { Box, Typography, useMediaQuery, useTheme } from "@mui/material";
+import { Box, Typography } from "@mui/material";
 import Image from "next/image";
 import { motion, useInView } from "framer-motion";
-import { BRAND_GRADIENT_TEXT_SX } from "@/lib/theme";
+import {
+  NB_COLORS,
+  NB_DISPLAY_SX,
+  NB_MONO_SX,
+  NB_RULE,
+} from "@/lib/theme";
 
 // Metrics below reflect real numbers where available. LESGC reach is estimated
 // (see note field on the hero). Southside has no quantitative data yet, so the
@@ -45,7 +50,12 @@ type CaseStudy = {
   stats?: StatTile[];
 };
 
-const DONUT_COLORS = ["#E5C767", "#E89B3C", "#C9A227", "#D97706"];
+export const DONUT_COLORS = [
+  NB_COLORS.silver,
+  NB_COLORS.steel,
+  NB_COLORS.silverLight,
+  NB_COLORS.mutedOnInk,
+];
 
 const CASE_STUDIES: CaseStudy[] = [
   {
@@ -184,11 +194,9 @@ function HeroMetricView({
   inView: boolean;
 }) {
   const headlineSx = {
-    fontSize: { xs: "56px", md: "80px", lg: "96px" },
-    fontWeight: 900,
-    lineHeight: 1,
-    letterSpacing: "-0.03em",
-    ...BRAND_GRADIENT_TEXT_SX,
+    ...NB_DISPLAY_SX,
+    fontSize: { xs: 48, md: 64, lg: 80 },
+    color: NB_COLORS.ink,
   } as const;
 
   const count = useCountUp(
@@ -197,7 +205,7 @@ function HeroMetricView({
   );
 
   return (
-    <Box sx={{ textAlign: { xs: "center", md: "left" } }}>
+    <Box>
       {metric.kind === "count" ? (
         <Typography component="div" sx={headlineSx}>
           {metric.prefix}
@@ -212,10 +220,14 @@ function HeroMetricView({
           rel="noopener noreferrer"
           sx={{
             ...headlineSx,
-            textDecoration: "none",
             display: "inline-block",
-            transition: "filter 0.2s",
-            "&:hover": { filter: "brightness(1.1)" },
+            textDecoration: "underline",
+            textDecorationThickness: 3,
+            textUnderlineOffset: 6,
+            "&:hover": {
+              bgcolor: NB_COLORS.ink,
+              color: NB_COLORS.paperOnInk,
+            },
           }}
         >
           {metric.value}
@@ -228,11 +240,11 @@ function HeroMetricView({
 
       <Typography
         sx={{
+          ...NB_MONO_SX,
           mt: 1,
-          fontSize: { xs: "11px", md: "13px" },
-          letterSpacing: "0.18em",
-          color: "rgba(255,255,255,0.65)",
+          fontSize: { xs: 11, md: 12 },
           fontWeight: 700,
+          color: NB_COLORS.steel,
         }}
       >
         {metric.label}
@@ -241,10 +253,10 @@ function HeroMetricView({
       {metric.kind === "count" && metric.note ? (
         <Typography
           sx={{
+            ...NB_MONO_SX,
             mt: 0.75,
-            fontSize: { xs: "11px", md: "12px" },
-            color: "rgba(255,255,255,0.45)",
-            fontStyle: "italic",
+            fontSize: { xs: 10, md: 11 },
+            color: NB_COLORS.steel,
           }}
         >
           {metric.note}
@@ -270,15 +282,17 @@ function DonutChart({
   const circumference = 2 * Math.PI * radius;
   const total = slices.reduce((sum, s) => sum + s.value, 0);
 
-  let cumulative = 0;
-  const arcs = slices.map((slice) => {
+  const arcs = slices.reduce<
+    (DonutSlice & { dash: number; gap: number; offset: number; pct: number })[]
+  >((acc, slice) => {
     const fraction = slice.value / total;
     const dash = circumference * fraction;
     const gap = circumference - dash;
-    const offset = -cumulative;
-    cumulative += dash;
-    return { ...slice, dash, gap, offset, pct: Math.round(fraction * 100) };
-  });
+    const prev = acc[acc.length - 1];
+    const offset = prev ? prev.offset - prev.dash : 0;
+    acc.push({ ...slice, dash, gap, offset, pct: Math.round(fraction * 100) });
+    return acc;
+  }, []);
 
   return (
     <Box
@@ -301,7 +315,7 @@ function DonutChart({
             cy={center}
             r={radius}
             fill="none"
-            stroke="rgba(255,255,255,0.08)"
+            stroke={NB_COLORS.silverLight}
             strokeWidth={strokeWidth}
           />
           {arcs.map((arc) => (
@@ -324,10 +338,10 @@ function DonutChart({
       <Box sx={{ minWidth: 160 }}>
         <Typography
           sx={{
-            fontSize: { xs: "10px", md: "11px" },
-            letterSpacing: "0.18em",
-            color: "rgba(255,255,255,0.55)",
+            ...NB_MONO_SX,
+            fontSize: { xs: 10, md: 11 },
             fontWeight: 700,
+            color: NB_COLORS.steel,
             mb: 1,
           }}
         >
@@ -341,16 +355,16 @@ function DonutChart({
               alignItems: "center",
               gap: 1.25,
               py: 0.4,
-              fontSize: { xs: "13px", md: "14px" },
-              color: "rgba(255,255,255,0.9)",
+              fontSize: { xs: 13, md: 14 },
+              color: NB_COLORS.ink,
             }}
           >
             <Box
               sx={{
-                width: 10,
-                height: 10,
+                width: 12,
+                height: 12,
                 bgcolor: arc.color,
-                borderRadius: "2px",
+                border: NB_RULE,
                 flexShrink: 0,
               }}
             />
@@ -375,38 +389,39 @@ function StatCluster({ stats }: { stats: StatTile[] }) {
     <Box
       sx={{
         display: "grid",
-        gridTemplateColumns: { xs: "1fr 1fr", sm: "repeat(auto-fit, minmax(140px, 1fr))" },
+        gridTemplateColumns: {
+          xs: "1fr 1fr",
+          sm: "repeat(auto-fit, minmax(140px, 1fr))",
+        },
         gap: 2,
         width: "100%",
       }}
     >
-      {stats.map((s) => (
+      {stats.map((s, i) => (
         <Box
           key={s.label}
           sx={{
             p: 2,
-            border: "1px solid rgba(229,199,103,0.25)",
-            borderRadius: 2,
-            bgcolor: "rgba(229,199,103,0.04)",
+            border: NB_RULE,
+            bgcolor: i % 2 === 1 ? NB_COLORS.silverLight : NB_COLORS.surface,
             textAlign: "center",
           }}
         >
           <Typography
             sx={{
-              fontSize: { xs: "22px", md: "28px" },
-              fontWeight: 800,
-              ...BRAND_GRADIENT_TEXT_SX,
+              ...NB_DISPLAY_SX,
+              fontSize: { xs: 22, md: 28 },
+              color: NB_COLORS.ink,
             }}
           >
             {s.value}
           </Typography>
           <Typography
             sx={{
-              mt: 0.5,
-              fontSize: { xs: "10px", md: "11px" },
-              letterSpacing: "0.15em",
-              color: "rgba(255,255,255,0.55)",
-              fontWeight: 700,
+              ...NB_MONO_SX,
+              mt: 0.75,
+              fontSize: { xs: 10, md: 11 },
+              color: NB_COLORS.steel,
             }}
           >
             {s.label}
@@ -418,42 +433,69 @@ function StatCluster({ stats }: { stats: StatTile[] }) {
 }
 
 function CaseStudyCard({ study }: { study: CaseStudy }) {
-  const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down("md"));
   const metricsRef = useRef<HTMLDivElement>(null);
   const metricsInView = useInView(metricsRef, { once: true, amount: 0.3 });
 
   return (
-    <Box
-      sx={{
-        p: { xs: 2.5, md: 4 },
-        border: "1px solid rgba(229,199,103,0.15)",
-        borderRadius: "24px",
-        background:
-          "linear-gradient(180deg, rgba(229,199,103,0.03) 0%, rgba(0,0,0,0) 100%)",
-      }}
-    >
+    <Box sx={{ borderTop: NB_RULE }}>
+      {/* Job header bar */}
+      <Box
+        sx={{
+          bgcolor: NB_COLORS.ink,
+          color: NB_COLORS.paperOnInk,
+          display: "flex",
+          alignItems: "center",
+          gap: { xs: 1.5, md: 3 },
+          px: { xs: 3, md: 6 },
+          py: 1.25,
+          flexWrap: "wrap",
+        }}
+      >
+        <Typography
+          sx={{
+            ...NB_MONO_SX,
+            fontSize: 12,
+            fontWeight: 700,
+            bgcolor: NB_COLORS.silver,
+            color: NB_COLORS.onSilver,
+            px: 1,
+            py: 0.25,
+          }}
+        >
+          FILE {study.number}
+        </Typography>
+        <Typography sx={{ ...NB_MONO_SX, fontSize: 12, fontWeight: 700 }}>
+          {study.client}
+        </Typography>
+        <Typography
+          sx={{
+            ...NB_MONO_SX,
+            fontSize: 12,
+            ml: "auto",
+            color: NB_COLORS.mutedOnInk,
+            display: { xs: "none", md: "block" },
+          }}
+        >
+          {study.category}
+        </Typography>
+      </Box>
+
+      {/* Plate + copy */}
       <Box
         sx={{
           display: "grid",
-          gridTemplateColumns: { xs: "1fr", md: "1.1fr 1fr" },
-          gap: { xs: 3, md: 6 },
-          alignItems: "center",
-          direction: !isMobile && parseInt(study.number) % 2 === 0 ? "rtl" : "ltr",
+          gridTemplateColumns: { xs: "1fr", md: "6fr 6fr" },
+          borderTop: NB_RULE,
         }}
       >
         <Box
           sx={{
-            direction: "ltr",
             position: "relative",
             width: "100%",
-            aspectRatio: study.youtubeId
-              ? "16 / 9"
-              : { xs: "4 / 3", md: "5 / 4" },
-            borderRadius: "18px",
-            overflow: "hidden",
-            boxShadow: "0 20px 60px rgba(0,0,0,0.5)",
-            bgcolor: "black",
+            aspectRatio: study.youtubeId ? "16 / 9" : "4 / 3",
+            bgcolor: NB_COLORS.well,
+            borderRight: { md: NB_RULE },
+            borderBottom: { xs: NB_RULE, md: "none" },
           }}
         >
           {study.youtubeId ? (
@@ -477,7 +519,7 @@ function CaseStudyCard({ study }: { study: CaseStudy }) {
               src={study.image}
               alt={study.imageAlt}
               fill
-              sizes="(max-width: 900px) 100vw, 55vw"
+              sizes="(max-width: 900px) 100vw, 50vw"
               style={{ objectFit: "cover" }}
             />
           )}
@@ -485,80 +527,43 @@ function CaseStudyCard({ study }: { study: CaseStudy }) {
 
         <Box
           sx={{
-            direction: "ltr",
+            px: { xs: 3, md: 6 },
+            py: { xs: 3, md: 5 },
             display: "flex",
             flexDirection: "column",
+            justifyContent: "center",
             gap: 2,
           }}
         >
-          <Box sx={{ display: "flex", alignItems: "baseline", gap: 2 }}>
-            <Typography
-              sx={{
-                fontSize: { xs: "60px", md: "96px" },
-                lineHeight: 1,
-                fontWeight: 900,
-                letterSpacing: "-0.04em",
-                ...BRAND_GRADIENT_TEXT_SX,
-              }}
-            >
-              {study.number}
-            </Typography>
-            <Box>
-              <Typography
-                sx={{
-                  fontSize: { xs: "10px", md: "12px" },
-                  letterSpacing: "0.15em",
-                  color: "rgba(255,255,255,0.6)",
-                  fontWeight: 600,
-                  mb: 0.5,
-                }}
-              >
-                {study.category}
-              </Typography>
-              <Typography
-                sx={{
-                  fontSize: { xs: "18px", md: "22px" },
-                  fontWeight: 700,
-                  letterSpacing: "0.05em",
-                }}
-              >
-                {study.client}
-              </Typography>
-            </Box>
-          </Box>
-
+          <Typography sx={{ ...NB_MONO_SX, fontSize: 12, color: NB_COLORS.steel }}>
+            {study.category}
+          </Typography>
           <Typography
+            variant="h3"
             sx={{
-              fontSize: { xs: "22px", md: "30px" },
-              fontWeight: 600,
-              lineHeight: 1.25,
-              mb: 1,
+              ...NB_DISPLAY_SX,
+              fontSize: { xs: 24, sm: 30, md: 34 },
+              color: NB_COLORS.ink,
             }}
           >
             {study.headline}
           </Typography>
-
-          <Typography
-            sx={{
-              fontSize: { xs: "15px", md: "16px" },
-              color: "rgba(255,255,255,0.8)",
-              lineHeight: 1.6,
-            }}
-          >
+          <Typography sx={{ fontSize: { xs: 15, md: 16 }, color: NB_COLORS.steel }}>
             {study.copy}
           </Typography>
         </Box>
       </Box>
 
+      {/* Metrics band */}
       <Box
         ref={metricsRef}
         sx={{
-          mt: { xs: 4, md: 5 },
-          pt: { xs: 3, md: 4 },
-          borderTop: "1px solid rgba(229,199,103,0.2)",
+          borderTop: NB_RULE,
+          px: { xs: 3, md: 6 },
+          py: { xs: 3, md: 4 },
           display: "grid",
           gridTemplateColumns: { xs: "1fr", md: "auto 1fr" },
-          gap: { xs: 4, md: 6 },
+          gap: { xs: 3, md: 6 },
           alignItems: "center",
         }}
       >
@@ -579,66 +584,59 @@ function CaseStudyCard({ study }: { study: CaseStudy }) {
 export default function CaseStudiesSection() {
   return (
     <Box
+      component="section"
       id="case-studies"
       sx={{
-        bgcolor: "black",
-        color: "white",
-        px: { xs: 2, md: 6 },
-        py: { xs: 8, md: 14 },
+        bgcolor: NB_COLORS.paper,
+        borderBottom: NB_RULE,
         scrollMarginTop: { xs: 24, md: 40 },
       }}
     >
-      <Box sx={{ maxWidth: 1280, mx: "auto" }}>
-        <Box sx={{ textAlign: "center", mb: { xs: 6, md: 10 } }}>
-          <Typography
-            variant="h2"
-            component="h2"
-            sx={{
-              fontSize: { xs: "34px", md: "56px", lg: "68px" },
-              fontWeight: "bold",
-              mb: 2,
-            }}
-          >
-            <Box component="span" sx={{ color: "white" }}>
-              SELECTED{" "}
-            </Box>
-            <Box component="span" sx={BRAND_GRADIENT_TEXT_SX}>
-              WORK
-            </Box>
-          </Typography>
-          <Typography
-            sx={{
-              fontSize: { xs: "16px", md: "20px" },
-              color: "rgba(255,255,255,0.8)",
-              maxWidth: 720,
-              mx: "auto",
-            }}
-          >
-            Five recent builds across charity, tech, creator, music, and CPG.
-            Same studio. Same team. Very different briefs.
-          </Typography>
-        </Box>
-
-        <Box
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "baseline",
+          justifyContent: "space-between",
+          px: { xs: 3, md: 6 },
+          py: { xs: 3, md: 4 },
+          borderBottom: NB_RULE,
+          flexWrap: "wrap",
+          gap: 1,
+        }}
+      >
+        <Typography
+          variant="h2"
           sx={{
-            display: "flex",
-            flexDirection: "column",
-            gap: { xs: 6, md: 10 },
+            ...NB_DISPLAY_SX,
+            fontSize: { xs: 32, sm: 48, lg: 64 },
+            color: NB_COLORS.ink,
           }}
         >
-          {CASE_STUDIES.map((study) => (
-            <motion.div
-              key={study.number}
-              initial={{ opacity: 0, y: 30 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true, amount: 0.2 }}
-              transition={{ duration: 0.6 }}
-            >
-              <CaseStudyCard study={study} />
-            </motion.div>
-          ))}
-        </Box>
+          SELECTED WORK
+        </Typography>
+        <Typography sx={{ ...NB_MONO_SX, fontSize: 12, color: NB_COLORS.steel }}>
+          CASE FILES · 05 ENTRIES
+        </Typography>
       </Box>
+
+      <Box sx={{ px: { xs: 3, md: 6 }, py: { xs: 2.5, md: 3 } }}>
+        <Typography sx={{ fontSize: { xs: 15, md: 17 }, color: NB_COLORS.steel, maxWidth: 720 }}>
+          Five recent builds across charity, tech, creator, music, and CPG.
+          Same studio. Same team. Very different briefs.
+        </Typography>
+      </Box>
+
+      {CASE_STUDIES.map((study) => (
+        <motion.div
+          key={study.number}
+          initial={{ opacity: 0, y: 30 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, amount: 0.2 }}
+          transition={{ duration: 0.6 }}
+        >
+          <CaseStudyCard study={study} />
+        </motion.div>
+      ))}
     </Box>
   );
 }

--- a/app/brand-activations/page.tsx
+++ b/app/brand-activations/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Box } from "@mui/material";
+import { NB_COLORS } from "@/lib/theme";
 import TrustWall, { TrustPress } from "../components/TrustWall";
 import SocialProofBar from "../components/SocialProofBar";
 import Footer from "../ui/Footer";
@@ -49,7 +50,7 @@ export const metadata: Metadata = {
 
 export default function BrandActivationsPage() {
   return (
-    <Box sx={{ bgcolor: "black" }}>
+    <Box component="main" sx={{ bgcolor: NB_COLORS.paper, color: NB_COLORS.ink }}>
       <BrandActivationsServiceJsonLd />
       <PageViewTracker />
       <BrandActivationsHero />

--- a/app/components/AboutUs.tsx
+++ b/app/components/AboutUs.tsx
@@ -3,16 +3,33 @@
 import { useRef } from "react";
 import { Box, Typography } from "@mui/material";
 import { motion } from "framer-motion";
+import {
+  NB_COLORS,
+  NB_DISPLAY_SX,
+  NB_MONO_SX,
+  NB_RULE,
+} from "@/lib/theme";
 
 export default function AboutUs() {
   const ref = useRef(null);
 
   return (
-    <Box ref={ref} sx={{ bgcolor: "black" }}>
+    <Box
+      component="section"
+      ref={ref}
+      sx={{ bgcolor: NB_COLORS.paper, borderBottom: NB_RULE }}
+    >
+      {/* Section header band */}
       <Box
         sx={{
-          width: "100%",
-          height: "auto",
+          display: "flex",
+          alignItems: "baseline",
+          justifyContent: "space-between",
+          px: { xs: 3, md: 6 },
+          py: { xs: 3, md: 4 },
+          borderBottom: NB_RULE,
+          flexWrap: "wrap",
+          gap: 1,
         }}
       >
         <motion.div
@@ -23,53 +40,51 @@ export default function AboutUs() {
           <Typography
             variant="h1"
             component="h1"
-            color="white"
             sx={{
-              fontSize: { xs: "55px", sm: "95px" },
-              fontWeight: "bold",
-              paddingTop: { xs: 8 },
-              marginBottom: { xs: "20px", md: "30px" },
-              paddingLeft: "10px",
-              paddingRight: "10px",
-              textAlign: "center",
+              ...NB_DISPLAY_SX,
+              fontSize: { xs: 40, sm: 64, lg: 80 },
+              color: NB_COLORS.ink,
             }}
           >
             ABOUT US
           </Typography>
         </motion.div>
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.2, duration: 0.5 }}
-        >
-          <Box sx={{ mx: { xs: 2, md: 10 } }}>
-            <Typography
-              variant="body1"
-              component="p"
-              color="white"
-              sx={{
-                fontSize: { xs: "14px", sm: "20px", md: "30px" },
-                marginTop: "10px",
-                marginLeft: "30px",
-                marginRight: "30px",
-                textAlign: "center",
-              }}
-            >
-              <Box component="span" sx={{ color: "#E5C767", fontWeight: 600 }}>
-                Drip Dome Productions
-              </Box>{" "}
-              is a majority women-owned, family-run business based in New York
-              City, with a presence in Los Angeles as well. We specialize in set
-              design, custom fabrication, murals, graphic design, photography,
-              and rentals. From photoshoots and music videos to large-scale
-              event installations, we bring creative visions to life with
-              artistry and precision. At Drip Dome, family values and
-              collaboration fuel our passion for creating extraordinary projects
-              that leave a lasting impact.
-            </Typography>
-          </Box>
-        </motion.div>
+        <Typography sx={{ ...NB_MONO_SX, fontSize: 12, color: NB_COLORS.steel }}>
+          THE STUDIO · WOMEN-OWNED · FAMILY-RUN
+        </Typography>
       </Box>
+
+      {/* Body band */}
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.2, duration: 0.5 }}
+      >
+        <Box sx={{ px: { xs: 3, md: 6 }, py: { xs: 4, md: 6 } }}>
+          <Typography
+            variant="body1"
+            component="p"
+            sx={{
+              fontSize: { xs: 16, sm: 18, md: 20 },
+              color: NB_COLORS.ink,
+              lineHeight: 1.7,
+              maxWidth: 880,
+            }}
+          >
+            <Box component="span" sx={{ fontWeight: 700 }}>
+              Drip Dome Productions
+            </Box>{" "}
+            is a majority women-owned, family-run business based in New York
+            City, with a presence in Los Angeles as well. We specialize in set
+            design, custom fabrication, murals, graphic design, photography,
+            and rentals. From photoshoots and music videos to large-scale
+            event installations, we bring creative visions to life with
+            artistry and precision. At Drip Dome, family values and
+            collaboration fuel our passion for creating extraordinary projects
+            that leave a lasting impact.
+          </Typography>
+        </Box>
+      </motion.div>
     </Box>
   );
 }

--- a/app/components/Contact.tsx
+++ b/app/components/Contact.tsx
@@ -3,50 +3,101 @@
 import { Box, Typography } from "@mui/material";
 import Footer from "../ui/Footer";
 import ContactForm from "./ContactForm";
+import {
+  NB_COLORS,
+  NB_DISPLAY_SX,
+  NB_MONO_SX,
+  NB_OUTLINE_TEXT_SX,
+  NB_RULE,
+} from "@/lib/theme";
+
+const DETAILS = [
+  { label: "LOCATIONS", value: "NEW YORK CITY + LOS ANGELES" },
+  { label: "INSTAGRAM", value: "@DRIPDOME" },
+  { label: "RESPONSE TIME", value: "WITHIN 48 HOURS" },
+];
 
 export default function Contact() {
   return (
     <>
-      <Box
-        sx={{
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "center",
-          px: { xs: 4, md: 8 },
-        }}
-      >
-        <Typography
-          variant="h2"
-          component="h2"
+      <Box component="section" sx={{ bgcolor: NB_COLORS.paper }}>
+        <Box
           sx={{
-            fontSize: { xs: "50px", md: "80px", lg: "90px" },
-            fontWeight: "bold",
-            marginBottom: "15px",
-            justifyContent: "center",
-            display: "flex",
-            color: "white",
-            whiteSpace: "nowrap",
+            display: "grid",
+            gridTemplateColumns: { xs: "1fr", md: "5fr 7fr" },
           }}
         >
-          Contact Us
-        </Typography>
+          {/* Left: intake header */}
+          <Box
+            sx={{
+              px: { xs: 3, md: 6 },
+              py: { xs: 4, md: 6 },
+              borderRight: { md: NB_RULE },
+              borderBottom: { xs: NB_RULE, md: "none" },
+              display: "flex",
+              flexDirection: "column",
+            }}
+          >
+            <Typography sx={{ ...NB_MONO_SX, fontSize: 12, color: NB_COLORS.steel, mb: 2 }}>
+              PROJECT INTAKE · FORM A
+            </Typography>
+            <Typography
+              variant="h2"
+              sx={{
+                ...NB_DISPLAY_SX,
+                fontSize: { xs: 40, sm: 56, lg: 72 },
+                color: NB_COLORS.ink,
+                mb: 1,
+              }}
+            >
+              LET&apos;S BUILD
+            </Typography>
+            <Typography
+              sx={{
+                ...NB_OUTLINE_TEXT_SX,
+                fontSize: { xs: 40, sm: 56, lg: 72 },
+                mb: 3,
+              }}
+            >
+              SOMETHING.
+            </Typography>
+            <Typography
+              sx={{ fontSize: { xs: 15, md: 17 }, color: NB_COLORS.ink, maxWidth: 420, mb: 4 }}
+            >
+              Big or small, every idea has the potential to shine. Tell us about
+              your project and let&apos;s build something amazing.
+            </Typography>
 
-        <Typography
-          variant="body2"
-          component="p"
-          sx={{
-            fontSize: { sm: "20px", md: "25px", lg: "30px" },
-            display: "flex",
-            textAlign: "center",
-            maxWidth: 900,
-            marginBottom: "30px",
-            color: "white",
-          }}
-        >
-          Big or small, every idea has the potential to shine. Tell us about
-          your project and let&apos;s build something amazing!
-        </Typography>
-        <ContactForm />
+            <Box sx={{ mt: "auto" }}>
+              {DETAILS.map((row) => (
+                <Box
+                  key={row.label}
+                  sx={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    gap: 2,
+                    py: 1.25,
+                    borderTop: NB_RULE,
+                  }}
+                >
+                  <Typography sx={{ ...NB_MONO_SX, fontSize: 11, color: NB_COLORS.steel }}>
+                    {row.label}
+                  </Typography>
+                  <Typography
+                    sx={{ ...NB_MONO_SX, fontSize: 11, fontWeight: 700, color: NB_COLORS.ink }}
+                  >
+                    {row.value}
+                  </Typography>
+                </Box>
+              ))}
+            </Box>
+          </Box>
+
+          {/* Right: form */}
+          <Box sx={{ px: { xs: 3, md: 6 }, py: { xs: 4, md: 6 } }}>
+            <ContactForm />
+          </Box>
+        </Box>
       </Box>
       <Footer />
     </>

--- a/app/components/ContactForm.tsx
+++ b/app/components/ContactForm.tsx
@@ -4,6 +4,52 @@ import { useRef, FormEvent } from "react";
 import { Box, Button, TextField } from "@mui/material";
 import ReCAPTCHA from "react-google-recaptcha";
 import { sendData } from "@/hooks/sendData";
+import {
+  FONT_MONO,
+  NB_BUTTON_SX,
+  NB_COLORS,
+  NB_RULE,
+  nbShadow,
+} from "@/lib/theme";
+
+const FIELD_SX = {
+  "& .MuiInputBase-root": {
+    bgcolor: NB_COLORS.surface,
+    color: NB_COLORS.ink,
+    borderRadius: 0,
+  },
+  "& .MuiOutlinedInput-notchedOutline": {
+    border: NB_RULE,
+  },
+  "& .MuiInputBase-root:hover .MuiOutlinedInput-notchedOutline": {
+    border: NB_RULE,
+  },
+  "& .MuiInputBase-root.Mui-focused .MuiOutlinedInput-notchedOutline": {
+    border: NB_RULE,
+  },
+  "& .MuiInputBase-root.Mui-focused": {
+    boxShadow: nbShadow(4),
+  },
+  "& .MuiInputBase-input::placeholder": {
+    fontFamily: FONT_MONO,
+    fontSize: 13,
+    letterSpacing: "0.08em",
+    color: NB_COLORS.steel,
+    opacity: 1,
+  },
+} as const;
+
+const FIELDS = [
+  { name: "name", placeholder: "NAME", type: "text", aria: "Name" },
+  { name: "instagram", placeholder: "INSTAGRAM", type: "text", aria: "Instagram" },
+  { name: "email", placeholder: "EMAIL", type: "email", aria: "Email" },
+  {
+    name: "referral",
+    placeholder: "HOW DID YOU HEAR ABOUT US?",
+    type: "text",
+    aria: "How did you hear about us",
+  },
+];
 
 export default function ContactForm() {
   const recaptchaRef = useRef<ReCAPTCHA>(null);
@@ -17,7 +63,6 @@ export default function ContactForm() {
         width: "100%",
         maxWidth: 900,
         mx: "auto",
-        mb: 4,
         gap: { xs: 2, md: 2.5 },
       }}
       onSubmit={async (e: FormEvent<HTMLFormElement>) => {
@@ -68,63 +113,18 @@ export default function ContactForm() {
         }
       }}
     >
-      <TextField
-        name="name"
-        placeholder="NAME"
-        required
-        fullWidth
-        inputProps={{ "aria-label": "Name" }}
-        sx={{
-          "& .MuiInputBase-root": { bgcolor: "white", color: "black" },
-          "& .MuiInputBase-input::placeholder": {
-            color: "rgba(0,0,0,0.7)",
-            opacity: 1,
-          },
-        }}
-      />
-      <TextField
-        name="instagram"
-        placeholder="INSTAGRAM"
-        required
-        fullWidth
-        inputProps={{ "aria-label": "Instagram" }}
-        sx={{
-          "& .MuiInputBase-root": { bgcolor: "white", color: "black" },
-          "& .MuiInputBase-input::placeholder": {
-            color: "rgba(0,0,0,0.7)",
-            opacity: 1,
-          },
-        }}
-      />
-      <TextField
-        name="email"
-        type="email"
-        placeholder="EMAIL"
-        required
-        fullWidth
-        inputProps={{ "aria-label": "Email" }}
-        sx={{
-          "& .MuiInputBase-root": { bgcolor: "white", color: "black" },
-          "& .MuiInputBase-input::placeholder": {
-            color: "rgba(0,0,0,0.7)",
-            opacity: 1,
-          },
-        }}
-      />
-      <TextField
-        name="referral"
-        placeholder="HOW DID YOU HEAR ABOUT US?"
-        required
-        fullWidth
-        inputProps={{ "aria-label": "How did you hear about us" }}
-        sx={{
-          "& .MuiInputBase-root": { bgcolor: "white", color: "black" },
-          "& .MuiInputBase-input::placeholder": {
-            color: "rgba(0,0,0,0.7)",
-            opacity: 1,
-          },
-        }}
-      />
+      {FIELDS.map((field) => (
+        <TextField
+          key={field.name}
+          name={field.name}
+          type={field.type}
+          placeholder={field.placeholder}
+          required
+          fullWidth
+          inputProps={{ "aria-label": field.aria }}
+          sx={FIELD_SX}
+        />
+      ))}
       <TextField
         name="message"
         placeholder="YOUR MESSAGE"
@@ -133,15 +133,9 @@ export default function ContactForm() {
         multiline
         minRows={4}
         inputProps={{ "aria-label": "Message" }}
-        sx={{
-          "& .MuiInputBase-root": { bgcolor: "white", color: "black" },
-          "& .MuiInputBase-input::placeholder": {
-            color: "rgba(0,0,0,0.7)",
-            opacity: 1,
-          },
-        }}
+        sx={FIELD_SX}
       />
-      <Box sx={{ mb: 1, display: "flex", justifyContent: "center" }}>
+      <Box sx={{ display: "flex", justifyContent: { xs: "center", md: "flex-start" } }}>
         <ReCAPTCHA
           ref={recaptchaRef}
           sitekey={process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY || ""}
@@ -149,19 +143,10 @@ export default function ContactForm() {
       </Box>
       <Button
         type="submit"
-        variant="contained"
-        sx={{
-          alignSelf: "center",
-          px: 4,
-          py: 1.5,
-          width: "80dvw",
-          maxWidth: 900,
-          fontWeight: 700,
-          bgcolor: "#16a34a",
-          "&:hover": { bgcolor: "#1d4ed8" },
-        }}
+        disableElevation
+        sx={{ ...NB_BUTTON_SX, width: "100%", py: 1.75, fontSize: 14 }}
       >
-        SEND
+        SEND IT →
       </Button>
     </Box>
   );

--- a/app/components/FeaturedProjects.tsx
+++ b/app/components/FeaturedProjects.tsx
@@ -1,17 +1,21 @@
 "use client";
 
-import { Box, Typography, useMediaQuery, useTheme } from "@mui/material";
-import { Swiper, SwiperSlide } from "swiper/react";
-import "swiper/css";
+import { useRef, useState } from "react";
 import Image from "next/image";
-import { Autoplay, EffectCards } from "swiper/modules";
-import { BRAND_GRADIENT_TEXT_SX } from "@/lib/theme";
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
+import { Box, IconButton, Typography } from "@mui/material";
+import {
+  NB_COLORS,
+  NB_DISPLAY_SX,
+  NB_MONO_SX,
+  NB_RULE,
+} from "@/lib/theme";
 
 const sections = [
   {
     header: "LOWER EAST SIDE GIRLS CLUB CHARITY EVENT",
-    blurb: `For a charity event hosted by Lower East Side Girls Club, DripDome Productions created a 10’ × 8’ Alice in Wonderland–inspired photo moment featuring custom, vinyl-wrapped playing cards with the organization’s initials, set against a lush garden wall backdrop. Fabricated off-site and installed in under two hours despite strict venue constraints, the installation was experienced by roughly 200 guests and cited by organizers as the highlight of the evening.
-`,
+    blurb: `For a charity event hosted by Lower East Side Girls Club, DripDome Productions created a 10' × 8' Alice in Wonderland inspired photo moment featuring custom, vinyl-wrapped playing cards with the organization's initials, set against a lush garden wall backdrop. Fabricated off-site and installed in under two hours despite strict venue constraints, the installation was experienced by roughly 200 guests and cited by organizers as the highlight of the evening.`,
     images: [
       "https://dripdome-site.s3.us-east-2.amazonaws.com/lesgc/view.jpg",
       "https://dripdome-site.s3.us-east-2.amazonaws.com/lesgc/render.jpg",
@@ -63,164 +67,193 @@ const sections = [
   },
 ];
 
-const FeaturedProjects = () => {
-  const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
+function Filmstrip({ images, alt }: { images: string[]; alt: string }) {
+  const trackRef = useRef<HTMLDivElement>(null);
+  const [index, setIndex] = useState(0);
+
+  const handleScroll = () => {
+    const el = trackRef.current;
+    if (!el) return;
+    const maxScroll = el.scrollWidth - el.clientWidth;
+    if (maxScroll <= 0) return;
+    setIndex(Math.round((el.scrollLeft / maxScroll) * (images.length - 1)));
+  };
+
+  const nudge = (dir: 1 | -1) => {
+    const el = trackRef.current;
+    if (!el) return;
+    el.scrollBy({ left: dir * el.clientWidth * 0.75, behavior: "smooth" });
+  };
 
   return (
-    <Box sx={{ px: 3, width: "100%", overflow: "hidden" }}>
-      {sections.map((section, index) => (
-        <Box
-          key={index}
-          sx={{
-            borderRadius: 4,
-            pt: { md: 8, lg: 8 },
-            mb: 6,
-          }}
-        >
+    <Box>
+      <Box
+        ref={trackRef}
+        onScroll={handleScroll}
+        sx={{
+          display: "flex",
+          overflowX: "auto",
+          scrollSnapType: "x mandatory",
+          scrollbarWidth: "none",
+          "&::-webkit-scrollbar": { display: "none" },
+        }}
+      >
+        {images.map((image, idx) => (
           <Box
+            key={image}
             sx={{
-              display: "flex",
-              flexDirection: isMobile
-                ? "column"
-                : index % 2 === 0
-                  ? "row"
-                  : "row-reverse",
-              alignItems: "center",
-              mb: "2rem",
-              width: "100%",
-              gap: "1.5rem",
-              overflow: "hidden",
-              border: "4px solid rgba(229, 199, 103, 0.3)",
-              borderRadius: "30px",
-              backgroundColor: "#121212",
-              paddingTop: {
-                xs: "20px",
-                sm: "20px",
-                md: "20px",
-                lg: "20px",
-                xl: "20px",
-              },
-              paddingBottom: {
-                xs: "0px",
-                sm: "20px",
-                md: "20px",
-                lg: "20px",
-                xl: "20px",
-              },
-              paddingLeft: {
-                xs: "0px",
-                sm: "20px",
-                md: "20px",
-                lg: "20px",
-                xl: "20px",
-              },
-              paddingRight: {
-                xs: "0px",
-                sm: "20px",
-                md: "20px",
-                lg: "20px",
-                xl: "20px",
-              },
+              flex: "0 0 auto",
+              width: { xs: "82%", sm: "60%", md: "44%" },
+              scrollSnapAlign: "start",
+              borderRight: idx < images.length - 1 ? NB_RULE : "none",
+              position: "relative",
+              aspectRatio: "4 / 3",
+              bgcolor: NB_COLORS.well,
             }}
           >
-            {/* Swiper with Cards Effect */}
-            <Box
+            <Image
+              src={image}
+              alt={`${alt}, frame ${idx + 1}`}
+              fill
+              sizes="(max-width: 600px) 82vw, 44vw"
+              style={{ objectFit: "cover" }}
+            />
+          </Box>
+        ))}
+      </Box>
+
+      {/* Control bar */}
+      <Box sx={{ display: "flex", alignItems: "center", borderTop: NB_RULE }}>
+        <IconButton
+          aria-label="Previous frame"
+          onClick={() => nudge(-1)}
+          sx={{
+            borderRadius: 0,
+            borderRight: NB_RULE,
+            color: NB_COLORS.ink,
+            px: 2.5,
+            py: 1,
+            "&:hover": { bgcolor: NB_COLORS.ink, color: NB_COLORS.paperOnInk },
+          }}
+        >
+          <ArrowBackIcon />
+        </IconButton>
+        <IconButton
+          aria-label="Next frame"
+          onClick={() => nudge(1)}
+          sx={{
+            borderRadius: 0,
+            borderRight: NB_RULE,
+            color: NB_COLORS.ink,
+            px: 2.5,
+            py: 1,
+            "&:hover": { bgcolor: NB_COLORS.ink, color: NB_COLORS.paperOnInk },
+          }}
+        >
+          <ArrowForwardIcon />
+        </IconButton>
+        <Typography sx={{ ...NB_MONO_SX, fontSize: 12, px: 2, color: NB_COLORS.steel }}>
+          FRAME {String(index + 1).padStart(2, "0")} /{" "}
+          {String(images.length).padStart(2, "0")}
+        </Typography>
+        <Typography
+          sx={{
+            ...NB_MONO_SX,
+            fontSize: 12,
+            px: 2,
+            ml: "auto",
+            color: NB_COLORS.steel,
+            display: { xs: "none", sm: "block" },
+          }}
+        >
+          DRAG OR SCROLL →
+        </Typography>
+      </Box>
+    </Box>
+  );
+}
+
+const FeaturedProjects = () => {
+  return (
+    <Box sx={{ bgcolor: NB_COLORS.paper }}>
+      {sections.map((section, index) => (
+        <Box
+          key={section.header}
+          sx={{ borderBottom: index < sections.length - 1 ? NB_RULE : "none" }}
+        >
+          {/* Project header bar */}
+          <Box
+            sx={{
+              bgcolor: NB_COLORS.ink,
+              color: NB_COLORS.paperOnInk,
+              display: "flex",
+              alignItems: "center",
+              gap: { xs: 1.5, md: 3 },
+              px: { xs: 3, md: 6 },
+              py: 1.25,
+              flexWrap: "wrap",
+            }}
+          >
+            <Typography
               sx={{
-                flex: 1,
-                width: "100%",
-                maxWidth: isMobile ? "100%" : "50%",
-                minWidth: 0,
-                display: "flex",
-                justifyContent: "center",
-                alignItems: "center",
-                overflow: "hidden",
+                ...NB_MONO_SX,
+                fontSize: 12,
+                fontWeight: 700,
+                bgcolor: NB_COLORS.silver,
+                color: NB_COLORS.onSilver,
+                px: 1,
+                py: 0.25,
               }}
             >
-              <Swiper
-                effect="cards"
-                grabCursor={true}
-                autoplay={{
-                  delay: 2500,
-                  disableOnInteraction: true,
-                }}
-                cardsEffect={{
-                  perSlideOffset: 8,
-                  perSlideRotate: 2,
-                  rotate: true,
-                  slideShadows: true,
-                }}
-                modules={[EffectCards, Autoplay]}
-                style={{ width: "100%" }}
-              >
-                {section.images.map((image, idx) => (
-                  <SwiperSlide
-                    key={idx}
-                    style={{
-                      display: "flex",
-                      justifyContent: "center",
-                      alignItems: "center",
-                    }}
-                  >
-                    <Box
-                      sx={{
-                        width: "100%",
-                        height: {
-                          xs: "300px",
-                          sm: "400px",
-                          md: "500px",
-                          lg: "600px",
-                        },
-                        position: "relative",
-                        borderRadius: "15px",
-                        overflow: "hidden",
-                        boxShadow: "0px 5px 20px rgba(0, 0, 0, 0.3)",
-                      }}
-                    >
-                      <Image
-                        src={image}
-                        alt={`${section.header}`}
-                        fill
-                        sizes="(max-width: 600px) 90vw, (max-width: 900px) 40vw, 40vw"
-                        style={{
-                          objectFit: "contain",
-                          borderRadius: "15px",
-                        }}
-                      />
-                    </Box>
-                  </SwiperSlide>
-                ))}
-              </Swiper>
-            </Box>
+              PROJECT {String(index + 1).padStart(2, "0")}
+            </Typography>
+            <Typography sx={{ ...NB_MONO_SX, fontSize: 12, fontWeight: 700 }}>
+              CASE FILE
+            </Typography>
+            <Typography
+              sx={{
+                ...NB_MONO_SX,
+                fontSize: 12,
+                ml: "auto",
+                color: NB_COLORS.mutedOnInk,
+                display: { xs: "none", md: "block" },
+              }}
+            >
+              {String(section.images.length).padStart(2, "0")} FRAMES ON FILE
+            </Typography>
+          </Box>
 
-            {/* Header and Blurb */}
+          <Filmstrip images={section.images} alt={section.header} />
+
+          {/* Project sheet copy */}
+          <Box
+            sx={{
+              display: "grid",
+              gridTemplateColumns: { xs: "1fr", md: "5fr 7fr" },
+              borderTop: NB_RULE,
+            }}
+          >
             <Box
               sx={{
-                flex: 1,
-                maxWidth: isMobile ? "100%" : "50%",
-                minWidth: 0,
-                textAlign: isMobile ? "center" : "left",
-                p: "0 10px 20px 10px",
+                px: { xs: 3, md: 6 },
+                py: { xs: 2.5, md: 4 },
+                borderRight: { md: NB_RULE },
+                borderBottom: { xs: NB_RULE, md: "none" },
               }}
             >
               <Typography
-                variant="h1"
+                variant="h3"
                 sx={{
-                  fontSize: { xs: "28px", sm: "36px", md: "40px", lg: "50px" },
-                  mb: "1.5rem",
-                  color: "white",
-                  "& span": BRAND_GRADIENT_TEXT_SX,
+                  ...NB_DISPLAY_SX,
+                  fontSize: { xs: 26, sm: 32, md: 38 },
+                  color: NB_COLORS.ink,
                 }}
               >
                 {section.header}
               </Typography>
-              <Typography
-                variant="body1"
-                sx={{
-                  fontSize: { xs: "14px", sm: "18px", md: "20px" },
-                  color: "#e0e0e0",
-                }}
-              >
+            </Box>
+            <Box sx={{ px: { xs: 3, md: 6 }, py: { xs: 2.5, md: 4 } }}>
+              <Typography sx={{ fontSize: { xs: 15, md: 17 }, color: NB_COLORS.ink }}>
                 {section.blurb}
               </Typography>
             </Box>

--- a/app/components/FoundersSection.tsx
+++ b/app/components/FoundersSection.tsx
@@ -1,8 +1,15 @@
 "use client";
 import React from "react";
-import { Box, Typography, useMediaQuery, useTheme } from "@mui/material";
+import { Box, Typography } from "@mui/material";
 import Image from "next/image";
 import { motion } from "framer-motion";
+import {
+  NB_COLORS,
+  NB_DISPLAY_SX,
+  NB_MONO_SX,
+  NB_RULE,
+  nbShadow,
+} from "@/lib/theme";
 
 const founders = [
   {
@@ -27,127 +34,108 @@ const founders = [
 ];
 
 const FoundersSection = () => {
-  const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
-
   return (
-    <Box sx={{ bgcolor: "black" }}>
-      <motion.div
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ delay: 0, duration: 0.5 }}
+    <Box
+      component="section"
+      sx={{ bgcolor: NB_COLORS.paper, borderBottom: NB_RULE }}
+    >
+      {/* Slim index bar */}
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          px: { xs: 3, md: 6 },
+          py: 1.25,
+          borderBottom: NB_RULE,
+          flexWrap: "wrap",
+          gap: 1,
+        }}
       >
-        <Box sx={{ pt: 12, bgcolor: "black" }}>
-          <Box
-            sx={{
-              paddingTop: "0px",
-              textAlign: "center",
-              background: "black",
-            }}
-          >
-            {/* <Typography
-              variant="h3"
-              sx={{
-                fontSize: {
-                  xs: '35px',
-                  sm: '50px',
-                  md: '50px',
-                  lg: '80px',
-                  xl: '80px',
-                },
-              }}
-              gutterBottom
-            >
-              MEET OUR FOUNDERS
-            </Typography> */}
+        <Typography
+          variant="h2"
+          sx={{
+            ...NB_MONO_SX,
+            fontSize: 12,
+            fontWeight: 700,
+            color: NB_COLORS.ink,
+          }}
+        >
+          FOUNDERS
+        </Typography>
+        <Typography sx={{ ...NB_MONO_SX, fontSize: 12, color: NB_COLORS.steel }}>
+          PERSONNEL FILE · 03 ENTRIES
+        </Typography>
+      </Box>
 
-            {/* Founders Box */}
+      {/* Founder plates */}
+      <Box
+        sx={{
+          display: "grid",
+          gridTemplateColumns: { xs: "1fr", sm: "repeat(3, 1fr)" },
+        }}
+      >
+        {founders.map((founder, index) => (
+          <motion.div
+            key={index}
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: index * 0.2, duration: 0.5 }}
+            style={{ height: "100%" }}
+          >
             <Box
               sx={{
-                padding: "2rem",
-                backgroundColor: "black",
+                height: "100%",
+                px: { xs: 3, md: 4 },
+                py: { xs: 4, md: 5 },
+                borderRight: { sm: index < founders.length - 1 ? NB_RULE : "none" },
+                borderBottom: {
+                  xs: index < founders.length - 1 ? NB_RULE : "none",
+                  sm: "none",
+                },
               }}
             >
+              <Typography
+                sx={{ ...NB_MONO_SX, fontSize: 12, color: NB_COLORS.steel, mb: 2 }}
+              >
+                FOUNDER {String(index + 1).padStart(2, "0")}
+              </Typography>
               <Box
                 sx={{
-                  display: "flex",
-                  flexDirection: isMobile ? "column" : "row",
-                  gap: "2rem",
-                  justifyContent: "center",
-                  alignItems: "center",
+                  position: "relative",
+                  aspectRatio: "1 / 1",
+                  border: NB_RULE,
+                  boxShadow: nbShadow(),
+                  bgcolor: NB_COLORS.surface,
+                  mb: 3,
                 }}
               >
-                {founders.map((founder, index) => (
-                  <motion.div
-                    key={index}
-                    initial={{ opacity: 0, y: 20 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    transition={{ delay: index * 0.2, duration: 0.5 }}
-                  >
-                    <Box
-                      sx={{
-                        textAlign: "center",
-                        flexShrink: 0,
-                        flexBasis: "12rem",
-                        justifyContent: "center",
-                        alignItems: "center",
-                      }}
-                    >
-                      <Box
-                        sx={{
-                          width: { xs: 192, lg: 288 },
-                          height: { xs: 192, lg: 288 },
-                          borderRadius: "50%",
-                          overflow: "hidden",
-                          display: "flex",
-                          justifyContent: "center",
-                          alignItems: "center",
-                          mb: 4,
-                        }}
-                      >
-                        <Image
-                          src={founder.photo}
-                          width={192}
-                          height={192}
-                          alt={
-                            typeof founder.name === "string"
-                              ? founder.name
-                              : "Founder image"
-                          }
-                          style={{
-                            objectFit: "cover",
-                            width: "100%",
-                            height: "100%",
-                          }}
-                        />
-                      </Box>
-                      <Typography
-                        variant="h5"
-                        sx={{
-                          color: "white",
-                          textAlign: "center",
-                          position: "relative",
-                          "&::after": {
-                            content: '""',
-                            display: "block",
-                            width: "40px",
-                            height: "2px",
-                            bgcolor: "#E5C767",
-                            mx: "auto",
-                            mt: 1,
-                          },
-                        }}
-                      >
-                        {founder.name}
-                      </Typography>
-                    </Box>
-                  </motion.div>
-                ))}
+                <Image
+                  src={founder.photo}
+                  fill
+                  sizes="(max-width: 600px) 90vw, 33vw"
+                  alt={
+                    typeof founder.name === "string"
+                      ? founder.name
+                      : "Founder image"
+                  }
+                  style={{ objectFit: "cover" }}
+                />
               </Box>
+              <Typography
+                variant="h3"
+                sx={{
+                  ...NB_DISPLAY_SX,
+                  fontSize: { xs: 20, md: 24 },
+                  color: NB_COLORS.ink,
+                }}
+              >
+                {founder.name}
+              </Typography>
             </Box>
-          </Box>
-        </Box>
-      </motion.div>
+          </motion.div>
+        ))}
+      </Box>
     </Box>
   );
 };

--- a/app/components/HomeFeaturedWork.tsx
+++ b/app/components/HomeFeaturedWork.tsx
@@ -1,207 +1,152 @@
 "use client";
 
 import Link from "next/link";
-import { Box, Typography, useMediaQuery, useTheme } from "@mui/material";
-import { Swiper, SwiperSlide } from "swiper/react";
-import "swiper/css";
-import Image from "next/image";
-import { Autoplay, EffectCards } from "swiper/modules";
-
-const S3 = "https://dripdome-site.s3.us-east-2.amazonaws.com";
-
-const projects = [
-  {
-    header: "GOOGLE PHOTOS VIDEO RECAP CAMPAIGN",
-    blurb: `For a branded project with Google Photos, DripDome Productions led production design, including set design, prop and furniture sourcing, and full set dressing. The shoot featured K-pop star EJAE as the model, with every visual element curated to support a clean, lifestyle-driven aesthetic aligned with the brand.`,
-    images: [
-      `${S3}/goog-photos/ejae.png`,
-      `${S3}/goog-photos/purple.jpg`,
-      `${S3}/goog-photos/red.jpg`,
-      `${S3}/goog-photos/laydown.jpg`,
-    ],
-  },
-  {
-    header: "THE SET OF NOTLOVELINE",
-    blurb: `Our team designed and fabricated the podcast set for Trisha Paytas and Tana Mongeau's NotLoveline show — racking up 19M+ views. We created a vaporwave inspired set with retro wallpaper, a neon sign, and a custom built and wired heart wall with alternating colors.`,
-    images: [
-      `${S3}/NLL/IMG_1.JPG`,
-      `${S3}/NLL/IMG_2.JPG`,
-      `${S3}/NLL/IMG_3.JPG`,
-      `${S3}/NLL/IMG_4.jpeg`,
-      `${S3}/NLL/IMG_5.jpeg`,
-    ],
-  },
-];
+import ArrowOutwardIcon from "@mui/icons-material/ArrowOutward";
+import { Box, Typography } from "@mui/material";
+import JobFile from "./JobFile";
+import { PROJECTS, VERTICALS, featuredProjects } from "@/lib/projects";
+import {
+  NB_COLORS,
+  NB_DISPLAY_SX,
+  NB_MONO_SX,
+  NB_RULE,
+} from "@/lib/theme";
 
 export default function HomeFeaturedWork() {
-  const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
+  const featured = featuredProjects();
 
   return (
     <Box
       component="section"
       id="featured-work"
       sx={{
-        px: 3,
-        width: "100%",
-        overflow: "hidden",
-        py: { xs: 4, md: 6 },
-        scrollMarginTop: "80px",
+        bgcolor: NB_COLORS.paper,
+        borderBottom: NB_RULE,
+        scrollMarginTop: "120px",
       }}
     >
-      <Typography
-        variant="h2"
+      {/* Section header */}
+      <Box
         sx={{
-          fontSize: { xs: "28px", sm: "45px", lg: "55px" },
-          fontWeight: "bold",
-          color: "white",
-          textAlign: "center",
-          mb: { xs: 3, md: 5 },
+          display: "flex",
+          alignItems: "baseline",
+          justifyContent: "space-between",
+          px: { xs: 3, md: 6 },
+          py: { xs: 3, md: 4 },
+          borderBottom: NB_RULE,
+          flexWrap: "wrap",
+          gap: 1,
         }}
       >
-        Featured Work
-      </Typography>
-
-      {projects.map((section, index) => (
-        <Box
-          key={index}
-          sx={{
-            borderRadius: 4,
-            pt: { md: 4, lg: 4 },
-            mb: 4,
-          }}
-        >
-          <Box
-            sx={{
-              display: "flex",
-              flexDirection: isMobile
-                ? "column"
-                : index % 2 === 0
-                  ? "row"
-                  : "row-reverse",
-              alignItems: "center",
-              mb: "2rem",
-              width: "100%",
-              gap: "1.5rem",
-              overflow: "hidden",
-              border: "4px solid rgba(229, 199, 103, 0.3)",
-              borderRadius: "30px",
-              backgroundColor: "#121212",
-              p: { xs: "20px 0 0 0", sm: "20px" },
-            }}
-          >
-            <Box
-              sx={{
-                flex: 1,
-                width: "100%",
-                maxWidth: isMobile ? "100%" : "50%",
-                minWidth: 0,
-                display: "flex",
-                justifyContent: "center",
-                alignItems: "center",
-                overflow: "hidden",
-              }}
-            >
-              <Swiper
-                effect="cards"
-                grabCursor={true}
-                autoplay={{ delay: 2500, disableOnInteraction: true }}
-                cardsEffect={{
-                  perSlideOffset: 8,
-                  perSlideRotate: 2,
-                  rotate: true,
-                  slideShadows: true,
-                }}
-                modules={[EffectCards, Autoplay]}
-                style={{ width: "100%" }}
-              >
-                {section.images.map((image, idx) => (
-                  <SwiperSlide
-                    key={idx}
-                    style={{
-                      display: "flex",
-                      justifyContent: "center",
-                      alignItems: "center",
-                    }}
-                  >
-                    <Box
-                      sx={{
-                        width: "100%",
-                        height: {
-                          xs: "300px",
-                          sm: "400px",
-                          md: "500px",
-                          lg: "600px",
-                        },
-                        position: "relative",
-                        borderRadius: "15px",
-                        overflow: "hidden",
-                        boxShadow: "0px 5px 20px rgba(0, 0, 0, 0.3)",
-                      }}
-                    >
-                      <Image
-                        src={image}
-                        alt={section.header}
-                        fill
-                        sizes="(max-width: 600px) 90vw, 40vw"
-                        style={{ objectFit: "contain", borderRadius: "15px" }}
-                      />
-                    </Box>
-                  </SwiperSlide>
-                ))}
-              </Swiper>
-            </Box>
-
-            <Box
-              sx={{
-                flex: 1,
-                maxWidth: isMobile ? "100%" : "50%",
-                minWidth: 0,
-                textAlign: isMobile ? "center" : "left",
-                p: "0 10px 20px 10px",
-              }}
-            >
-              <Typography
-                variant="h3"
-                sx={{
-                  fontSize: { xs: "24px", sm: "32px", md: "36px", lg: "44px" },
-                  mb: "1.5rem",
-                  color: "white",
-                  fontWeight: "bold",
-                }}
-              >
-                {section.header}
-              </Typography>
-              <Typography
-                variant="body1"
-                sx={{
-                  fontSize: { xs: "14px", sm: "18px", md: "20px" },
-                  color: "#e0e0e0",
-                }}
-              >
-                {section.blurb}
-              </Typography>
-            </Box>
-          </Box>
-        </Box>
-      ))}
-
-      <Box sx={{ textAlign: "center", mt: 2 }}>
         <Typography
-          component={Link}
-          href="/portfolio"
+          variant="h2"
           sx={{
-            color: "#E5C767",
-            fontSize: { xs: "14px", sm: "16px" },
-            fontWeight: 700,
-            letterSpacing: "0.06em",
-            textDecoration: "none",
-            "&:hover": { textDecoration: "underline" },
+            ...NB_DISPLAY_SX,
+            fontSize: { xs: 32, sm: 48, lg: 64 },
+            color: NB_COLORS.ink,
           }}
         >
-          See All Projects &rarr;
+          THE ARCHIVE
+        </Typography>
+        <Typography sx={{ ...NB_MONO_SX, fontSize: 12, color: NB_COLORS.steel }}>
+          MASTER INDEX · EVERY BUILD ON FILE
         </Typography>
       </Box>
+
+      {featured.map((project) => (
+        <JobFile key={project.slug} project={project} />
+      ))}
+
+      {/* Full index: every job, including legacy verticals */}
+      <Box
+        sx={{
+          px: { xs: 3, md: 6 },
+          py: 1.25,
+          bgcolor: NB_COLORS.silverLight,
+          borderBottom: NB_RULE,
+        }}
+      >
+        <Typography sx={{ ...NB_MONO_SX, fontSize: 12, fontWeight: 700, color: NB_COLORS.ink }}>
+          FULL INDEX · {String(PROJECTS.length).padStart(2, "0")} JOBS
+        </Typography>
+      </Box>
+
+      {PROJECTS.map((project, i) => {
+        const vertical = VERTICALS[project.vertical];
+        const href = vertical.href ?? "/#contact";
+        return (
+          <Box
+            key={project.slug}
+            component={Link}
+            href={href}
+            sx={{
+              display: "grid",
+              gridTemplateColumns: {
+                xs: "auto 1fr auto",
+                md: "80px 240px 1fr auto auto",
+              },
+              alignItems: "center",
+              gap: { xs: 2, md: 3 },
+              px: { xs: 3, md: 6 },
+              py: { xs: 1.75, md: 2 },
+              borderBottom: i < PROJECTS.length - 1 ? NB_RULE : "none",
+              textDecoration: "none",
+              color: NB_COLORS.ink,
+              "&:hover": {
+                bgcolor: NB_COLORS.ink,
+                color: NB_COLORS.paperOnInk,
+                "& .index-meta": { color: NB_COLORS.mutedOnInk },
+              },
+            }}
+          >
+            <Typography
+              className="index-meta"
+              sx={{ ...NB_MONO_SX, fontSize: 12, color: NB_COLORS.steel }}
+            >
+              JOB {project.jobNo}
+            </Typography>
+            <Typography
+              sx={{
+                ...NB_MONO_SX,
+                fontSize: { xs: 11, md: 13 },
+                fontWeight: 700,
+                color: "inherit",
+              }}
+            >
+              {project.client}
+            </Typography>
+            <Typography
+              sx={{
+                fontSize: { xs: 13, md: 16 },
+                color: "inherit",
+                gridColumn: { xs: "2 / 4", md: "auto" },
+              }}
+            >
+              {project.title}
+            </Typography>
+            <Typography
+              className="index-meta"
+              sx={{
+                ...NB_MONO_SX,
+                fontSize: 11,
+                color: NB_COLORS.steel,
+                display: { xs: "none", md: "block" },
+              }}
+            >
+              {vertical.label}
+              {vertical.legacy ? " · LEGACY" : ""}
+            </Typography>
+            <ArrowOutwardIcon
+              sx={{
+                fontSize: 18,
+                color: "inherit",
+                display: { xs: "none", md: "block" },
+                justifySelf: "end",
+              }}
+            />
+          </Box>
+        );
+      })}
     </Box>
   );
 }

--- a/app/components/HomeHero.tsx
+++ b/app/components/HomeHero.tsx
@@ -5,201 +5,270 @@ import Image from "next/image";
 import Link from "next/link";
 import { motion } from "framer-motion";
 import {
-  BRAND_GRADIENT_BUTTON_SX,
-  BRAND_GRADIENT_TEXT_SX,
+  NB_BUTTON_OUTLINE_SX,
+  NB_BUTTON_SX,
+  NB_COLORS,
+  NB_DISPLAY_SX,
+  NB_MONO_SX,
+  NB_OUTLINE_TEXT_SX,
+  NB_RULE,
+  NB_TAG_SX,
+  nbShadow,
 } from "@/lib/theme";
 
-// TODO: replace hero image with a 15s branded reel once produced
-// (use <video autoPlay muted loop playsInline> with a webm/mp4 hosted on S3).
 const HERO_IMAGE =
   "https://dripdome-site.s3.us-east-2.amazonaws.com/NLL/IMG_1.JPG";
 
 const BADGES = ["WOMEN OWNED", "NYC + LA", "CONCEPT TO COMPLETION"];
 
-export default function HomeHero() {
+const TICKER_ITEMS = [
+  "SET DESIGN",
+  "CUSTOM FABRICATION",
+  "POP-UP ACTIVATIONS",
+  "PRODUCTION DESIGN",
+  "PODCAST STUDIOS",
+  "IMMERSIVE ENVIRONMENTS",
+];
+
+function Ticker() {
+  const strip = (key: string) => (
+    <Box
+      key={key}
+      aria-hidden={key === "b"}
+      sx={{ display: "flex", alignItems: "center", flexShrink: 0 }}
+    >
+      {TICKER_ITEMS.map((item) => (
+        <Typography
+          key={item}
+          component="span"
+          sx={{
+            ...NB_MONO_SX,
+            fontSize: { xs: 12, md: 14 },
+            fontWeight: 700,
+            color: NB_COLORS.paperOnInk,
+            px: 3,
+            py: 1.25,
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 3,
+            whiteSpace: "nowrap",
+            "&::after": { content: '"●"', fontSize: 8, color: NB_COLORS.mutedOnInk },
+          }}
+        >
+          {item}
+        </Typography>
+      ))}
+    </Box>
+  );
+
   return (
     <Box
       sx={{
-        position: "relative",
-        minHeight: { xs: "90vh", md: "100vh" },
-        width: "100%",
+        bgcolor: NB_COLORS.ink,
+        borderTop: NB_RULE,
         overflow: "hidden",
         display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        bgcolor: "black",
-        pt: { xs: "95px", md: "40px" },
       }}
     >
-      <Image
-        src={HERO_IMAGE}
-        alt="DripDome set design and experiential build"
-        fill
-        priority
-        sizes="100vw"
-        style={{ objectFit: "cover", opacity: 0.55 }}
-      />
       <Box
         sx={{
-          position: "absolute",
-          inset: 0,
-          background:
-            "linear-gradient(180deg, rgba(0,0,0,0.35) 0%, rgba(0,0,0,0.85) 100%)",
-        }}
-      />
-
-      <Box
-        sx={{
-          position: "relative",
-          zIndex: 1,
-          px: { xs: 3, md: 8 },
-          py: { xs: 10, md: 10, lg: 10, xl: 12 },
-          maxWidth: 1200,
-          width: "100%",
-          textAlign: "center",
+          display: "flex",
+          width: "max-content",
+          animation: "nb-ticker 28s linear infinite",
         }}
       >
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6 }}
+        {strip("a")}
+        {strip("b")}
+      </Box>
+    </Box>
+  );
+}
+
+export default function HomeHero() {
+  return (
+    <Box component="section" sx={{ bgcolor: NB_COLORS.paper, borderBottom: NB_RULE }}>
+      <Box
+        sx={{
+          display: "grid",
+          gridTemplateColumns: { xs: "1fr", md: "7fr 5fr" },
+          maxWidth: 1440,
+          mx: "auto",
+        }}
+      >
+        {/* Left: type column */}
+        <Box
+          sx={{
+            px: { xs: 3, md: 6 },
+            py: { xs: 5, md: 8 },
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "center",
+            borderRight: { md: NB_RULE },
+          }}
         >
-          <Box
-            sx={{
-              display: "flex",
-              flexWrap: "wrap",
-              justifyContent: "center",
-              gap: 1.5,
-              mb: 4,
-            }}
+          <motion.div
+            initial={{ opacity: 0, y: 16 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5 }}
           >
-            {BADGES.map((badge) => (
+            <Typography
+              sx={{ ...NB_MONO_SX, fontSize: 12, color: NB_COLORS.steel, mb: 2 }}
+            >
+              DRIPDOME PRODUCTIONS · SPEC 001 · EXPERIENTIAL DESIGN STUDIO
+            </Typography>
+          </motion.div>
+
+          <motion.div
+            initial={{ opacity: 0, y: 24 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.1 }}
+          >
+            <Typography
+              variant="h1"
+              sx={{
+                ...NB_DISPLAY_SX,
+                fontSize: { xs: 52, sm: 76, md: 84, lg: 104, xl: 120 },
+                color: NB_COLORS.ink,
+                mb: 3,
+              }}
+            >
+              WE BUILD
+              <Box component="span" sx={{ ...NB_OUTLINE_TEXT_SX, display: "block" }}>
+                WORLDS.
+              </Box>
               <Box
-                key={badge}
+                component="span"
                 sx={{
-                  px: 2,
-                  py: 0.75,
-                  border: "1px solid rgba(229,199,103,0.6)",
-                  borderRadius: "999px",
-                  fontSize: { xs: "11px", md: "13px" },
-                  fontWeight: 600,
-                  letterSpacing: "0.1em",
-                  color: "white",
-                  bgcolor: "rgba(229,199,103,0.08)",
+                  display: "inline-block",
+                  fontSize: "0.35em",
+                  bgcolor: NB_COLORS.silver,
+                  color: NB_COLORS.onSilver,
+                  border: NB_RULE,
+                  boxShadow: nbShadow(),
+                  px: 1.5,
+                  py: 0.5,
+                  mt: 2,
                 }}
               >
-                {badge}
+                SETS. STAGES. STORIES.
               </Box>
-            ))}
-          </Box>
-        </motion.div>
+            </Typography>
+          </motion.div>
 
-        <motion.div
-          initial={{ opacity: 0, y: 30 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.8, delay: 0.1 }}
-        >
-          <Typography
-            variant="h1"
-            component="h1"
-            sx={{
-              fontSize: {
-                xs: "40px",
-                sm: "56px",
-                md: "64px",
-                lg: "72px",
-                xl: "96px",
-              },
-              fontWeight: "bold",
-              lineHeight: 1.05,
-              color: "white",
-              mb: { xs: 3, lg: 2.5, xl: 3 },
-            }}
+          <motion.div
+            initial={{ opacity: 0, y: 16 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.25 }}
           >
-            WE BUILD WORLDS.
-            <br />
-            <Box component="span" sx={BRAND_GRADIENT_TEXT_SX}>
-              SETS. STAGES. STORIES.
+            <Typography
+              sx={{
+                fontSize: { xs: 16, md: 18 },
+                color: NB_COLORS.ink,
+                maxWidth: 560,
+                mb: 4,
+              }}
+            >
+              Production design and custom fabrication trusted by world-class
+              brands and A-list talent. From concept to completion in NYC and LA.
+            </Typography>
+          </motion.div>
+
+          <motion.div
+            initial={{ opacity: 0, y: 16 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.35 }}
+          >
+            <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2, mb: 4 }}>
+              <Button
+                component={Link}
+                href="/#contact"
+                disableElevation
+                sx={{ ...NB_BUTTON_SX, px: 4, py: 1.5, fontSize: { xs: 13, md: 14 } }}
+              >
+                START A PROJECT
+              </Button>
+              <Button
+                component={Link}
+                href="/portfolio"
+                disableElevation
+                sx={{
+                  ...NB_BUTTON_OUTLINE_SX,
+                  px: 4,
+                  py: 1.5,
+                  fontSize: { xs: 13, md: 14 },
+                }}
+              >
+                VIEW PORTFOLIO
+              </Button>
             </Box>
-          </Typography>
-        </motion.div>
 
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.8, delay: 0.25 }}
-        >
-          <Typography
-            sx={{
-              fontSize: { xs: "16px", md: "18px", lg: "18px", xl: "22px" },
-              color: "rgba(255,255,255,0.9)",
-              maxWidth: 820,
-              mx: "auto",
-              mb: { xs: 4, lg: 4, xl: 5 },
-            }}
-          >
-            Production design and custom fabrication trusted by world-class
-            brands and A-list talent. From concept to completion in NYC and LA.
-          </Typography>
-        </motion.div>
+            <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1.5 }}>
+              {BADGES.map((badge) => (
+                <Box key={badge} sx={{ ...NB_TAG_SX, fontSize: { xs: 10, md: 11 } }}>
+                  {badge}
+                </Box>
+              ))}
+            </Box>
+          </motion.div>
+        </Box>
 
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.8, delay: 0.4 }}
+        {/* Right: mounted exhibit plate */}
+        <Box
+          sx={{
+            px: { xs: 3, md: 5 },
+            py: { xs: 4, md: 8 },
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            bgcolor: { md: NB_COLORS.silverLight },
+            borderTop: { xs: NB_RULE, md: "none" },
+          }}
         >
-          <Box
-            sx={{
-              display: "flex",
-              flexWrap: "wrap",
-              justifyContent: "center",
-              gap: 2,
-            }}
+          <motion.div
+            initial={{ opacity: 0, y: 24 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.2 }}
+            style={{ width: "100%", maxWidth: 520 }}
           >
-            <Button
-              component={Link}
-              href="/portfolio"
-              variant="contained"
+            <Box
               sx={{
-                px: 4,
-                py: 1.75,
-                fontSize: { xs: "14px", md: "16px" },
-                fontWeight: 700,
-                letterSpacing: "0.08em",
-                ...BRAND_GRADIENT_BUTTON_SX,
+                border: NB_RULE,
+                bgcolor: NB_COLORS.surface,
+                boxShadow: nbShadow(10),
+                p: 1,
               }}
             >
-              VIEW PORTFOLIO
-            </Button>
-            <Button
-              component="a"
-              href="#contact"
-              onClick={(e: React.MouseEvent<HTMLAnchorElement>) => {
-                e.preventDefault();
-                document
-                  .getElementById("contact")
-                  ?.scrollIntoView({ behavior: "smooth" });
-              }}
-              variant="outlined"
-              sx={{
-                px: 4,
-                py: 1.75,
-                fontSize: { xs: "14px", md: "16px" },
-                fontWeight: 700,
-                letterSpacing: "0.08em",
-                color: "white",
-                borderColor: "rgba(255,255,255,0.6)",
-                "&:hover": {
-                  borderColor: "white",
-                  bgcolor: "rgba(255,255,255,0.08)",
-                },
-              }}
-            >
-              START A PROJECT
-            </Button>
-          </Box>
-        </motion.div>
+              <Box sx={{ position: "relative", aspectRatio: "4 / 3", border: NB_RULE }}>
+                <Image
+                  src={HERO_IMAGE}
+                  alt="DripDome set build for the NotLoveline podcast"
+                  fill
+                  priority
+                  sizes="(max-width: 900px) 90vw, 40vw"
+                  style={{ objectFit: "cover" }}
+                />
+              </Box>
+              <Box
+                sx={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  pt: 1,
+                  px: 0.5,
+                }}
+              >
+                <Typography sx={{ ...NB_MONO_SX, fontSize: 11, color: NB_COLORS.steel }}>
+                  FIG. 01 · NOTLOVELINE SET
+                </Typography>
+                <Typography sx={{ ...NB_MONO_SX, fontSize: 11, color: NB_COLORS.steel }}>
+                  19M+ VIEWS
+                </Typography>
+              </Box>
+            </Box>
+          </motion.div>
+        </Box>
       </Box>
+
+      <Ticker />
     </Box>
   );
 }

--- a/app/components/HowWeWork.tsx
+++ b/app/components/HowWeWork.tsx
@@ -1,25 +1,34 @@
 "use client";
 
 import { useRef } from "react";
+import Link from "next/link";
 import { Box, Button, Typography } from "@mui/material";
 import { motion, useInView } from "framer-motion";
-import { BRAND_GRADIENT } from "@/lib/theme";
+import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
+import {
+  NB_BUTTON_SX,
+  NB_COLORS,
+  NB_DISPLAY_SX,
+  NB_MONO_SX,
+  NB_OUTLINE_TEXT_SX,
+  NB_RULE,
+} from "@/lib/theme";
 
 const steps = [
   {
     number: "01",
     title: "TELL US YOUR VISION",
-    description: "Share your idea — any stage is fine",
+    description: "Share your idea. Any stage is fine.",
   },
   {
     number: "02",
-    title: "WE DESIGN & BUILD",
-    description: "We handle concept, fabrication & logistics",
+    title: "WE DESIGN + BUILD",
+    description: "We handle concept, fabrication and logistics.",
   },
   {
     number: "03",
     title: "YOU SHOW UP TO SOMETHING AMAZING",
-    description: "On-time, on-budget, every time",
+    description: "On-time, on-budget, every time.",
   },
 ];
 
@@ -31,164 +40,113 @@ export default function HowWeWork() {
     <Box
       component="section"
       ref={ref}
-      sx={{
-        width: "100%",
-        maxWidth: "1200px",
-        mx: "auto",
-        px: { xs: 3, md: 6 },
-        py: { xs: 6, md: 10 },
-      }}
+      sx={{ bgcolor: NB_COLORS.paper, borderBottom: NB_RULE }}
     >
-      <Typography
-        variant="h2"
-        sx={{
-          fontSize: { xs: "28px", sm: "40px", lg: "50px" },
-          fontWeight: "bold",
-          color: "white",
-          textAlign: "center",
-          mb: { xs: 4, md: 6 },
-        }}
-      >
-        How We Work
-      </Typography>
-
       <Box
         sx={{
           display: "flex",
-          flexDirection: { xs: "column", md: "row" },
-          alignItems: { xs: "flex-start", md: "flex-start" },
-          gap: { xs: 0, md: 3 },
-          position: "relative",
+          alignItems: "baseline",
+          justifyContent: "space-between",
+          px: { xs: 3, md: 6 },
+          py: { xs: 3, md: 4 },
+          borderBottom: NB_RULE,
+          flexWrap: "wrap",
+          gap: 1,
+        }}
+      >
+        <Typography
+          variant="h2"
+          sx={{
+            ...NB_DISPLAY_SX,
+            fontSize: { xs: 32, sm: 48, lg: 64 },
+            color: NB_COLORS.ink,
+          }}
+        >
+          HOW WE WORK
+        </Typography>
+        <Typography sx={{ ...NB_MONO_SX, fontSize: 12, color: NB_COLORS.steel }}>
+          PROCESS · THREE STEPS, NO MYSTERY
+        </Typography>
+      </Box>
+
+      <Box
+        sx={{
+          display: "grid",
+          gridTemplateColumns: { xs: "1fr", md: "repeat(3, 1fr)" },
         }}
       >
         {steps.map((step, i) => (
           <motion.div
             key={step.number}
-            initial={{ opacity: 0, y: 30 }}
+            initial={{ opacity: 0, y: 24 }}
             animate={inView ? { opacity: 1, y: 0 } : {}}
-            transition={{ duration: 0.6, delay: i * 0.2 }}
-            style={{ flex: 1, width: "100%" }}
+            transition={{ duration: 0.5, delay: i * 0.15 }}
           >
             <Box
               sx={{
-                display: "flex",
-                flexDirection: { xs: "row", md: "column" },
-                alignItems: { xs: "flex-start", md: "center" },
-                textAlign: { xs: "left", md: "center" },
-                gap: { xs: 2, md: 0 },
-                position: "relative",
-                pb: { xs: 3, md: 0 },
+                height: "100%",
+                px: { xs: 3, md: 4 },
+                py: { xs: 3, md: 5 },
+                borderRight: { md: i < steps.length - 1 ? NB_RULE : "none" },
+                borderBottom: { xs: i < steps.length - 1 ? NB_RULE : "none", md: "none" },
               }}
             >
-              {/* Step number circle */}
-              <Box
+              <Typography
                 sx={{
-                  width: 48,
-                  height: 48,
-                  minWidth: 48,
-                  borderRadius: "50%",
-                  border: "2px solid #E5C767",
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  mb: { md: 2 },
+                  ...NB_OUTLINE_TEXT_SX,
+                  fontSize: { xs: 64, md: 96 },
+                  mb: 2,
                 }}
               >
-                <Typography
-                  sx={{
-                    color: "#E5C767",
-                    fontWeight: 800,
-                    fontSize: "16px",
-                  }}
-                >
-                  {step.number}
-                </Typography>
-              </Box>
-
-              {/* Connecting line (desktop only, between steps) */}
-              {i < steps.length - 1 && (
-                <Box
-                  sx={{
-                    display: { xs: "none", md: "block" },
-                    position: "absolute",
-                    top: 24,
-                    left: "calc(50% + 30px)",
-                    width: "calc(100% - 60px)",
-                    height: "2px",
-                    bgcolor: "rgba(229,199,103,0.25)",
-                  }}
-                />
-              )}
-
-              {/* Connecting line (mobile only, vertical) */}
-              {i < steps.length - 1 && (
-                <Box
-                  sx={{
-                    display: { xs: "block", md: "none" },
-                    position: "absolute",
-                    top: 48,
-                    left: 23,
-                    width: "2px",
-                    height: "calc(100% - 48px)",
-                    bgcolor: "rgba(229,199,103,0.25)",
-                  }}
-                />
-              )}
-
-              <Box>
-                <Typography
-                  sx={{
-                    fontSize: { xs: "14px", sm: "16px", md: "18px" },
-                    fontWeight: 800,
-                    color: "white",
-                    letterSpacing: "0.06em",
-                    mb: 0.5,
-                  }}
-                >
-                  {step.title}
-                </Typography>
-                <Typography
-                  sx={{
-                    fontSize: { xs: "13px", sm: "14px" },
-                    color: "rgba(255,255,255,0.6)",
-                  }}
-                >
-                  {step.description}
-                </Typography>
-              </Box>
+                {step.number}
+              </Typography>
+              <Typography
+                sx={{
+                  ...NB_DISPLAY_SX,
+                  fontSize: { xs: 18, md: 22 },
+                  color: NB_COLORS.ink,
+                  mb: 1.5,
+                }}
+              >
+                {step.title}
+              </Typography>
+              <Typography sx={{ fontSize: { xs: 14, md: 16 }, color: NB_COLORS.steel }}>
+                {step.description}
+              </Typography>
             </Box>
           </motion.div>
         ))}
       </Box>
 
-      <Box sx={{ textAlign: "center", mt: { xs: 4, md: 6 } }}>
-        <Button
-          component="a"
-          href="#contact"
-          variant="contained"
-          disableElevation
+      {/* CTA band */}
+      <Box
+        sx={{
+          borderTop: NB_RULE,
+          bgcolor: NB_COLORS.silver,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 2,
+          px: { xs: 3, md: 6 },
+          py: { xs: 2.5, md: 3 },
+          flexWrap: "wrap",
+        }}
+      >
+        <Typography
           sx={{
-            borderRadius: 999,
-            px: 3,
-            py: 1.1,
-            fontWeight: 800,
-            letterSpacing: "0.08em",
-            fontSize: "13px",
-            color: "black",
-            background: BRAND_GRADIENT,
-            boxShadow: "0 10px 30px rgba(229,199,103,0.25)",
-            "&:hover": {
-              background: BRAND_GRADIENT,
-              filter: "brightness(0.92)",
-              boxShadow: "0 12px 34px rgba(229,199,103,0.35)",
-            },
+            ...NB_DISPLAY_SX,
+            fontSize: { xs: 20, md: 28 },
+            color: NB_COLORS.onSilver,
           }}
-          onClick={(e: React.MouseEvent<HTMLAnchorElement>) => {
-            e.preventDefault();
-            document
-              .getElementById("contact")
-              ?.scrollIntoView({ behavior: "smooth" });
-          }}
+        >
+          READY WHEN YOU ARE.
+        </Typography>
+        <Button
+          component={Link}
+          href="/#contact"
+          disableElevation
+          endIcon={<ArrowForwardIcon />}
+          sx={{ ...NB_BUTTON_SX, px: 3.5, py: 1.25, fontSize: 13 }}
         >
           START YOUR PROJECT
         </Button>

--- a/app/components/JobFile.tsx
+++ b/app/components/JobFile.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+import { useRef, useState } from "react";
+import Link from "next/link";
+import Image from "next/image";
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
+import { Box, IconButton, Typography } from "@mui/material";
+import type { Project } from "@/lib/projects";
+import { VERTICALS } from "@/lib/projects";
+import {
+  NB_COLORS,
+  NB_DISPLAY_SX,
+  NB_MONO_SX,
+  NB_RULE,
+} from "@/lib/theme";
+
+function Filmstrip({ images, alt }: { images: string[]; alt: string }) {
+  const trackRef = useRef<HTMLDivElement>(null);
+  const [index, setIndex] = useState(0);
+
+  const handleScroll = () => {
+    const el = trackRef.current;
+    if (!el) return;
+    const maxScroll = el.scrollWidth - el.clientWidth;
+    if (maxScroll <= 0) return;
+    setIndex(Math.round((el.scrollLeft / maxScroll) * (images.length - 1)));
+  };
+
+  const nudge = (dir: 1 | -1) => {
+    const el = trackRef.current;
+    if (!el) return;
+    el.scrollBy({ left: dir * el.clientWidth * 0.75, behavior: "smooth" });
+  };
+
+  return (
+    <Box>
+      <Box
+        ref={trackRef}
+        onScroll={handleScroll}
+        sx={{
+          display: "flex",
+          overflowX: "auto",
+          scrollSnapType: "x mandatory",
+          scrollbarWidth: "none",
+          "&::-webkit-scrollbar": { display: "none" },
+        }}
+      >
+        {images.map((image, idx) => (
+          <Box
+            key={image}
+            sx={{
+              flex: "0 0 auto",
+              width: { xs: "82%", sm: "60%", md: "44%" },
+              scrollSnapAlign: "start",
+              borderRight: idx < images.length - 1 ? NB_RULE : "none",
+              position: "relative",
+              aspectRatio: "4 / 3",
+              bgcolor: NB_COLORS.silverLight,
+            }}
+          >
+            <Image
+              src={image}
+              alt={`${alt}, frame ${idx + 1}`}
+              fill
+              sizes="(max-width: 600px) 82vw, 44vw"
+              style={{ objectFit: "cover" }}
+            />
+          </Box>
+        ))}
+      </Box>
+
+      {/* Control bar */}
+      <Box sx={{ display: "flex", alignItems: "center", borderTop: NB_RULE }}>
+        <IconButton
+          aria-label="Previous frame"
+          onClick={() => nudge(-1)}
+          sx={{
+            borderRadius: 0,
+            borderRight: NB_RULE,
+            color: NB_COLORS.ink,
+            px: 2.5,
+            py: 1,
+            "&:hover": { bgcolor: NB_COLORS.ink, color: NB_COLORS.paperOnInk },
+          }}
+        >
+          <ArrowBackIcon />
+        </IconButton>
+        <IconButton
+          aria-label="Next frame"
+          onClick={() => nudge(1)}
+          sx={{
+            borderRadius: 0,
+            borderRight: NB_RULE,
+            color: NB_COLORS.ink,
+            px: 2.5,
+            py: 1,
+            "&:hover": { bgcolor: NB_COLORS.ink, color: NB_COLORS.paperOnInk },
+          }}
+        >
+          <ArrowForwardIcon />
+        </IconButton>
+        <Typography sx={{ ...NB_MONO_SX, fontSize: 12, px: 2, color: NB_COLORS.steel }}>
+          FRAME {String(index + 1).padStart(2, "0")} /{" "}
+          {String(images.length).padStart(2, "0")}
+        </Typography>
+        <Typography
+          sx={{
+            ...NB_MONO_SX,
+            fontSize: 12,
+            px: 2,
+            ml: "auto",
+            color: NB_COLORS.steel,
+            display: { xs: "none", sm: "block" },
+          }}
+        >
+          DRAG OR SCROLL →
+        </Typography>
+      </Box>
+    </Box>
+  );
+}
+
+export default function JobFile({ project }: { project: Project }) {
+  const vertical = VERTICALS[project.vertical];
+
+  return (
+    <Box sx={{ borderBottom: NB_RULE }}>
+      {/* Job header bar */}
+      <Box
+        sx={{
+          bgcolor: NB_COLORS.ink,
+          color: NB_COLORS.paperOnInk,
+          display: "flex",
+          alignItems: "center",
+          gap: { xs: 1.5, md: 3 },
+          px: { xs: 3, md: 6 },
+          py: 1.25,
+          flexWrap: "wrap",
+        }}
+      >
+        <Typography
+          sx={{
+            ...NB_MONO_SX,
+            fontSize: 12,
+            fontWeight: 700,
+            bgcolor: NB_COLORS.silver,
+            color: NB_COLORS.onSilver,
+            px: 1,
+            py: 0.25,
+          }}
+        >
+          JOB {project.jobNo}
+        </Typography>
+        {vertical.href ? (
+          <Typography
+            component={Link}
+            href={vertical.href}
+            sx={{
+              ...NB_MONO_SX,
+              fontSize: 12,
+              fontWeight: 700,
+              color: "inherit",
+              textDecoration: "underline",
+              textUnderlineOffset: 3,
+              "&:hover": { color: NB_COLORS.mutedOnInk },
+            }}
+          >
+            {vertical.label}
+          </Typography>
+        ) : (
+          <Typography sx={{ ...NB_MONO_SX, fontSize: 12, fontWeight: 700 }}>
+            {vertical.label}
+          </Typography>
+        )}
+        <Typography sx={{ ...NB_MONO_SX, fontSize: 12 }}>
+          CLIENT: {project.client}
+        </Typography>
+        <Typography
+          sx={{
+            ...NB_MONO_SX,
+            fontSize: 12,
+            ml: "auto",
+            color: NB_COLORS.mutedOnInk,
+            display: { xs: "none", md: "block" },
+          }}
+        >
+          {project.scope}
+        </Typography>
+      </Box>
+
+      <Filmstrip images={project.images} alt={project.title} />
+
+      {/* Job sheet copy */}
+      <Box
+        sx={{
+          display: "grid",
+          gridTemplateColumns: { xs: "1fr", md: "5fr 7fr" },
+          borderTop: NB_RULE,
+        }}
+      >
+        <Box
+          sx={{
+            px: { xs: 3, md: 6 },
+            py: { xs: 2.5, md: 4 },
+            borderRight: { md: NB_RULE },
+            borderBottom: { xs: NB_RULE, md: "none" },
+          }}
+        >
+          <Typography
+            variant="h3"
+            sx={{
+              ...NB_DISPLAY_SX,
+              fontSize: { xs: 26, sm: 32, md: 38 },
+              color: NB_COLORS.ink,
+              mb: 2,
+            }}
+          >
+            {project.title}
+          </Typography>
+          <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
+            {project.stats.map((stat) => (
+              <Box
+                key={stat.label}
+                sx={{ border: NB_RULE, px: 1.25, py: 0.5 }}
+              >
+                <Typography
+                  component="span"
+                  sx={{ ...NB_MONO_SX, fontSize: 12, fontWeight: 700, color: NB_COLORS.ink }}
+                >
+                  {stat.value}
+                </Typography>
+                <Typography
+                  component="span"
+                  sx={{ ...NB_MONO_SX, fontSize: 10, color: NB_COLORS.steel, ml: 0.75 }}
+                >
+                  {stat.label}
+                </Typography>
+              </Box>
+            ))}
+          </Box>
+        </Box>
+        <Box sx={{ px: { xs: 3, md: 6 }, py: { xs: 2.5, md: 4 } }}>
+          <Typography sx={{ fontSize: { xs: 15, md: 17 }, color: NB_COLORS.ink }}>
+            {project.blurb}
+          </Typography>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/app/components/PhotoPageCarousels.tsx
+++ b/app/components/PhotoPageCarousels.tsx
@@ -1,162 +1,165 @@
 "use client";
 
-import React from "react";
-import { Swiper, SwiperSlide } from "swiper/react";
-import { Autoplay } from "swiper/modules";
-import { Box, Typography } from "@mui/material";
-import { photographyData } from "../portfolio/data";
+import React, { useRef, useState } from "react";
 import Image from "next/image";
-import "swiper/css";
-import "swiper/css/pagination";
-import "swiper/css/effect-coverflow";
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
+import { Box, IconButton, Typography } from "@mui/material";
+import { photographyData } from "../portfolio/data";
+import {
+  NB_COLORS,
+  NB_DISPLAY_SX,
+  NB_MONO_SX,
+  NB_RULE,
+} from "@/lib/theme";
 
-const PhotoPageCarousels: React.FC = () => {
+function ArchiveFilmstrip({ images, alt }: { images: string[]; alt: string }) {
+  const trackRef = useRef<HTMLDivElement>(null);
+  const [index, setIndex] = useState(0);
+
+  const handleScroll = () => {
+    const el = trackRef.current;
+    if (!el) return;
+    const maxScroll = el.scrollWidth - el.clientWidth;
+    if (maxScroll <= 0) return;
+    setIndex(Math.round((el.scrollLeft / maxScroll) * (images.length - 1)));
+  };
+
+  const nudge = (dir: 1 | -1) => {
+    const el = trackRef.current;
+    if (!el) return;
+    el.scrollBy({ left: dir * el.clientWidth * 0.75, behavior: "smooth" });
+  };
+
   return (
-    <>
-      {/* Mobile Container */}
+    <Box>
       <Box
+        ref={trackRef}
+        onScroll={handleScroll}
         sx={{
-          width: "100%",
-          overflow: "hidden",
-          display: { xs: "flex", md: "none" },
-          flexDirection: "column",
-          gap: "20px",
-          justifyContent: "center",
-          alignItems: "center",
-          p: 1,
+          display: "flex",
+          overflowX: "auto",
+          scrollSnapType: "x mandatory",
+          scrollbarWidth: "none",
+          "&::-webkit-scrollbar": { display: "none" },
         }}
       >
-        {photographyData.map((section, index) => (
-          <Box key={index} sx={{ width: "100%", overflow: "hidden" }}>
-            <Typography
-              variant="h1"
-              component="h1"
-              color="white"
-              sx={{
-                fontSize: { xs: "30px", sm: "55px", lg: "70px" },
-                fontWeight: "bold",
-                paddingTop: { xs: "30px", sm: "50px", md: "80px" },
-                marginBottom: { xs: "20px", md: "30px", lg: "40px" },
-                paddingLeft: "10px",
-                paddingRight: "10px",
-                textAlign: "center",
-              }}
-            >
-              {section.category}
-            </Typography>
-            <Swiper
-              key={index}
-              style={{
-                borderRadius: "20px",
-              }}
-              loop={true}
-              autoplay={{
-                delay: 0,
-                disableOnInteraction: true,
-                reverseDirection: index % 2 === 1,
-              }}
-              speed={1000}
-              slidesPerView={2.5}
-              spaceBetween={30}
-              modules={[Autoplay]}
-              freeMode={true}
-            >
-              {section.images.map((image, idx) => (
-                <SwiperSlide
-                  key={idx}
-                  style={{
-                    display: "flex",
-                    justifyContent: "center",
-                    alignItems: "center",
-                    width: "100%",
-                    height: "100%",
-                    maxWidth: "500px",
-                    aspectRatio: "1",
-                    borderRadius: "20px",
-                  }}
-                >
-                  <Image
-                    src={image}
-                    fill
-                    objectFit="contain"
-                    alt={`${section.category} ${idx + 1}`}
-                  />
-                </SwiperSlide>
-              ))}
-            </Swiper>
+        {images.map((image, idx) => (
+          <Box
+            key={image}
+            sx={{
+              flex: "0 0 auto",
+              width: { xs: "72%", sm: "44%", md: "30%", lg: "24%" },
+              scrollSnapAlign: "start",
+              borderRight: idx < images.length - 1 ? NB_RULE : "none",
+              position: "relative",
+              aspectRatio: "3 / 4",
+              bgcolor: NB_COLORS.well,
+            }}
+          >
+            <Image
+              src={image}
+              alt={`${alt}, frame ${idx + 1}`}
+              fill
+              sizes="(max-width: 600px) 72vw, (max-width: 900px) 44vw, 24vw"
+              style={{ objectFit: "cover" }}
+              loading="lazy"
+            />
           </Box>
         ))}
       </Box>
 
-      {/* Desktop Container */}
-      <Box
-        sx={{
-          display: { xs: "none", lg: "block" },
-          width: "90dvw",
-          justifySelf: "center",
-          overflow: "hidden",
-        }}
-      >
-        {photographyData.map((section, index) => {
-          return (
-            <Box key={index} sx={{ width: "100%", overflow: "hidden" }}>
-              <Typography
-                variant="h1"
-                component="h1"
-                color="white"
-                sx={{
-                  fontSize: { xs: "30px", sm: "55px", lg: "70px" },
-                  fontWeight: "bold",
-                  paddingTop: { xs: "30px", md: "30px" },
-                  marginBottom: { xs: "20px", md: "30px" },
-                  paddingLeft: "10px",
-                  paddingRight: "10px",
-                  textAlign: "center",
-                }}
-              >
-                {section.category}
-              </Typography>
-              <Swiper
-                key={index}
-                loop={true}
-                autoplay={{
-                  delay: 0,
-                  disableOnInteraction: true,
-                  reverseDirection: index % 2 === 1,
-                }}
-                speed={3000}
-                slidesPerView={3}
-                spaceBetween={40}
-                modules={[Autoplay]}
-                freeMode={true}
-                style={{
-                  borderRadius: "50px",
-                }}
-              >
-                {section.images.map((image, idx) => (
-                  <SwiperSlide
-                    key={idx}
-                    style={{
-                      display: "flex",
-                      justifyContent: "center",
-                      alignItems: "center",
-                      width: "500px",
-                      height: "600px",
-                    }}
-                  >
-                    <Image
-                      src={image}
-                      fill
-                      objectFit="contain"
-                      alt={`${section.category} ${idx + 1}`}
-                    />
-                  </SwiperSlide>
-                ))}
-              </Swiper>
-            </Box>
-          );
-        })}
+      {/* Control bar */}
+      <Box sx={{ display: "flex", alignItems: "center", borderTop: NB_RULE }}>
+        <IconButton
+          aria-label="Previous frame"
+          onClick={() => nudge(-1)}
+          sx={{
+            borderRadius: 0,
+            borderRight: NB_RULE,
+            color: NB_COLORS.ink,
+            px: 2.5,
+            py: 1,
+            "&:hover": { bgcolor: NB_COLORS.ink, color: NB_COLORS.paperOnInk },
+          }}
+        >
+          <ArrowBackIcon />
+        </IconButton>
+        <IconButton
+          aria-label="Next frame"
+          onClick={() => nudge(1)}
+          sx={{
+            borderRadius: 0,
+            borderRight: NB_RULE,
+            color: NB_COLORS.ink,
+            px: 2.5,
+            py: 1,
+            "&:hover": { bgcolor: NB_COLORS.ink, color: NB_COLORS.paperOnInk },
+          }}
+        >
+          <ArrowForwardIcon />
+        </IconButton>
+        <Typography sx={{ ...NB_MONO_SX, fontSize: 12, px: 2, color: NB_COLORS.steel }}>
+          FRAME {String(index + 1).padStart(2, "0")} /{" "}
+          {String(images.length).padStart(2, "0")}
+        </Typography>
+        <Typography
+          sx={{
+            ...NB_MONO_SX,
+            fontSize: 12,
+            px: 2,
+            ml: "auto",
+            color: NB_COLORS.steel,
+            display: { xs: "none", sm: "block" },
+          }}
+        >
+          DRAG OR SCROLL →
+        </Typography>
       </Box>
+    </Box>
+  );
+}
+
+const PhotoPageCarousels: React.FC = () => {
+  return (
+    <>
+      {photographyData.map((section, index) => (
+        <Box
+          key={section.category}
+          component="section"
+          sx={{ bgcolor: NB_COLORS.paper, borderBottom: NB_RULE }}
+        >
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "baseline",
+              justifyContent: "space-between",
+              px: { xs: 3, md: 6 },
+              py: { xs: 3, md: 4 },
+              borderBottom: NB_RULE,
+              flexWrap: "wrap",
+              gap: 1,
+            }}
+          >
+            <Typography
+              variant="h2"
+              sx={{
+                ...NB_DISPLAY_SX,
+                fontSize: { xs: 32, sm: 48, lg: 64 },
+                color: NB_COLORS.ink,
+              }}
+            >
+              {section.category}
+            </Typography>
+            <Typography sx={{ ...NB_MONO_SX, fontSize: 12, color: NB_COLORS.steel }}>
+              ARCHIVE {String(index + 1).padStart(2, "0")} ·{" "}
+              {String(section.images.length).padStart(2, "0")} FRAMES
+            </Typography>
+          </Box>
+
+          <ArchiveFilmstrip images={section.images} alt={section.category} />
+        </Box>
+      ))}
     </>
   );
 };

--- a/app/components/PressSection.tsx
+++ b/app/components/PressSection.tsx
@@ -1,17 +1,27 @@
 import React from "react";
 import { Box, Typography } from "@mui/material";
+import ArrowOutwardIcon from "@mui/icons-material/ArrowOutward";
+import {
+  NB_COLORS,
+  NB_DISPLAY_SX,
+  NB_MONO_SX,
+  NB_RULE,
+} from "@/lib/theme";
 
 const pressItems = [
   {
-    headline: "BUSINESS INSIDER - BELLA THORNE COACHELLA AFTERPARTY",
+    outlet: "Business Insider",
+    headline: "Bella Thorne Coachella Afterparty",
     url: "https://www.businessinsider.com/bella-thorne-coachella-after-party-photos-diplo-2022-4",
   },
   {
-    headline: "FORBES - BEST CANNED COCKTAIL ORIGINAL SOUTHSIDE",
+    outlet: "Forbes",
+    headline: "Best Canned Cocktail Original Southside",
     url: "https://www.forbes.com/sites/karlaalindahao/2024/03/01/best-canned-cocktail-original-southside/",
   },
   {
-    headline: "ROLLING STONE - THEIA RETURNS TO ALT-POP",
+    outlet: "Rolling Stone",
+    headline: "Theia Returns to Alt-Pop",
     url: "https://au.rollingstone.com/music/music-news/theia-crucified-by-u-45218/",
   },
 ];
@@ -19,65 +29,95 @@ const pressItems = [
 const PressSection = () => {
   return (
     <Box
-      sx={{ display: "flex", alignItems: "center", justifyContent: "center" }}
+      component="section"
+      sx={{ bgcolor: NB_COLORS.paper, borderBottom: NB_RULE }}
     >
       <Box
         sx={{
           display: "flex",
-          flexDirection: "column",
-          gap: 2,
-          textAlign: "center",
-          width: "80vw",
+          alignItems: "baseline",
+          justifyContent: "space-between",
+          px: { xs: 3, md: 6 },
+          py: { xs: 3, md: 4 },
+          borderBottom: NB_RULE,
+          flexWrap: "wrap",
+          gap: 1,
         }}
       >
         <Typography
-          variant="h1"
-          component="h1"
+          variant="h2"
           sx={{
-            textDecoration: "none",
-            color: "white",
-
-            mb: 2,
-            fontSize: { xs: "30px", sm: "80px" },
+            ...NB_DISPLAY_SX,
+            fontSize: { xs: 32, sm: 48, lg: 64 },
+            color: NB_COLORS.ink,
           }}
         >
-          Our Work in the Press
+          OUR WORK IN THE PRESS
         </Typography>
-        {pressItems.map((item, index) => (
-          <Box
-            key={index}
+        <Typography sx={{ ...NB_MONO_SX, fontSize: 12, color: NB_COLORS.steel }}>
+          PRESS INDEX · EXTERNAL LINKS
+        </Typography>
+      </Box>
+
+      {pressItems.map((item, i) => (
+        <Box
+          key={item.url}
+          component="a"
+          href={item.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          sx={{
+            display: "grid",
+            gridTemplateColumns: { xs: "auto 1fr auto", md: "80px 240px 1fr auto" },
+            alignItems: "center",
+            gap: { xs: 2, md: 3 },
+            px: { xs: 3, md: 6 },
+            py: { xs: 2, md: 2.5 },
+            borderBottom: i < pressItems.length - 1 ? NB_RULE : "none",
+            textDecoration: "none",
+            color: NB_COLORS.ink,
+            "&:hover": {
+              bgcolor: NB_COLORS.ink,
+              color: NB_COLORS.paperOnInk,
+              "& .press-meta": { color: NB_COLORS.mutedOnInk },
+            },
+          }}
+        >
+          <Typography
+            className="press-meta"
+            sx={{ ...NB_MONO_SX, fontSize: 12, color: NB_COLORS.steel }}
+          >
+            P.{String(i + 1).padStart(2, "0")}
+          </Typography>
+          <Typography
             sx={{
-              padding: 2,
-              border: "1px solid #ccc",
-              borderRadius: 1,
-              backgroundColor: "white",
-              textAlign: "center",
-              color: "black",
-              transition: "all 0.3s ease",
-              "&:hover": {
-                backgroundColor: "black",
-                color: "white",
-              },
+              ...NB_MONO_SX,
+              fontSize: { xs: 12, md: 14 },
+              fontWeight: 700,
+              color: "inherit",
             }}
           >
-            <Typography
-              variant="h2"
-              component="a"
-              href={item.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              sx={{
-                display: "block",
-                textDecoration: "none",
-                color: "inherit",
-                fontSize: { xs: "20px", sm: "30px" },
-              }}
-            >
-              {item.headline}
-            </Typography>
-          </Box>
-        ))}
-      </Box>
+            {item.outlet}
+          </Typography>
+          <Typography
+            sx={{
+              fontSize: { xs: 14, md: 17 },
+              color: "inherit",
+              gridColumn: { xs: "2 / 4", md: "auto" },
+            }}
+          >
+            {item.headline}
+          </Typography>
+          <ArrowOutwardIcon
+            sx={{
+              fontSize: 20,
+              color: "inherit",
+              display: { xs: "none", md: "block" },
+              justifySelf: "end",
+            }}
+          />
+        </Box>
+      ))}
     </Box>
   );
 };

--- a/app/components/RentalGrid.tsx
+++ b/app/components/RentalGrid.tsx
@@ -1,16 +1,15 @@
 "use client";
 
 import { useState } from "react";
-import {
-  Box,
-  Card,
-  CardContent,
-  CardMedia,
-  Chip,
-  Grid,
-  Typography,
-} from "@mui/material";
+import { Box, ButtonBase, Typography } from "@mui/material";
 import { rentalEquipment, categories } from "../rentals/data";
+import {
+  NB_BORDER_WIDTH,
+  NB_COLORS,
+  NB_DISPLAY_SX,
+  NB_MONO_SX,
+  NB_RULE,
+} from "@/lib/theme";
 
 export default function RentalGrid() {
   const [selectedCategory, setSelectedCategory] = useState("All");
@@ -21,114 +20,150 @@ export default function RentalGrid() {
       : rentalEquipment.filter((item) => item.category === selectedCategory);
 
   return (
-    <Box sx={{ p: 3, width: "100%" }}>
+    <Box sx={{ width: "100%" }}>
+      {/* Filter bar */}
       <Box
         sx={{
           display: "flex",
-          gap: 2,
+          alignItems: "center",
           flexWrap: "wrap",
-          mb: 6,
-          justifyContent: "center",
+          gap: 1.5,
+          px: { xs: 3, md: 6 },
+          py: { xs: 2, md: 2.5 },
+          borderBottom: NB_RULE,
         }}
       >
-        {categories.map((cat) => (
-          <Chip
-            key={cat}
-            label={cat.toUpperCase()}
-            onClick={() => setSelectedCategory(cat)}
-            variant={selectedCategory === cat ? "filled" : "outlined"}
-            color={selectedCategory === cat ? "primary" : "default"}
-            sx={{
-              bgcolor: selectedCategory === cat ? "#E5C767" : "black",
-              color: "white",
-              borderColor:
-                selectedCategory === cat ? "#E5C767" : "rgba(255,255,255,0.3)",
-              "&:hover": {
-                bgcolor:
-                  selectedCategory === cat
-                    ? "#d1008f"
-                    : "rgba(229, 199, 103, 0.1)",
-                borderColor: "#E5C767",
-              },
-            }}
-          />
-        ))}
-      </Box>
-
-      <Grid container spacing={3} justifyContent="center">
-        {filtered.map((item) => (
-          <Grid item xs={12} sm={6} md={4} lg={3} key={item.id}>
-            <Card
+        <Typography sx={{ ...NB_MONO_SX, fontSize: 12, color: NB_COLORS.steel, mr: 0.5 }}>
+          FILTER:
+        </Typography>
+        {categories.map((cat) => {
+          const selected = selectedCategory === cat;
+          return (
+            <ButtonBase
+              key={cat}
+              onClick={() => setSelectedCategory(cat)}
+              aria-pressed={selected}
               sx={{
-                height: { xs: "300px", sm: "350px", md: "400px" },
-                width: "100%",
-                display: "flex",
-                flexDirection: "column",
-                backgroundColor: "rgba(100, 100, 100, 0.5)",
-                justifyContent: "center",
-                alignItems: "center",
-                transition: "box-shadow 0.3s ease",
-                borderRadius: "10px",
+                ...NB_MONO_SX,
+                fontSize: 12,
+                fontWeight: 700,
+                px: 1.5,
+                py: 0.5,
+                border: NB_RULE,
+                borderRadius: 0,
+                bgcolor: selected ? NB_COLORS.ink : NB_COLORS.surface,
+                color: selected ? NB_COLORS.paperOnInk : NB_COLORS.ink,
                 "&:hover": {
-                  boxShadow: 4,
+                  bgcolor: selected ? NB_COLORS.ink : NB_COLORS.silverLight,
                 },
               }}
             >
+              {cat.toUpperCase()}
+            </ButtonBase>
+          );
+        })}
+      </Box>
+
+      {/* Equipment index grid: cells share NB_RULE dividers; the outer
+          negative margin hides the trailing right/bottom rules so the
+          section band supplies the outer frame. */}
+      <Box sx={{ overflow: "hidden" }}>
+        <Box
+          sx={{
+            display: "grid",
+            gridTemplateColumns: {
+              xs: "1fr",
+              sm: "repeat(2, 1fr)",
+              md: "repeat(3, 1fr)",
+              lg: "repeat(4, 1fr)",
+            },
+            mr: `-${NB_BORDER_WIDTH}px`,
+            mb: `-${NB_BORDER_WIDTH}px`,
+          }}
+        >
+          {filtered.map((item, i) => (
+            <Box
+              key={item.name}
+              sx={{
+                display: "flex",
+                flexDirection: "column",
+                borderRight: NB_RULE,
+                borderBottom: NB_RULE,
+                bgcolor: i % 2 === 1 ? NB_COLORS.silverLight : NB_COLORS.paper,
+              }}
+            >
+              {/* Framed image plate */}
               <Box
                 sx={{
-                  height: "60%",
-                  width: "100%",
+                  borderBottom: NB_RULE,
+                  bgcolor: NB_COLORS.surface,
+                  aspectRatio: "4 / 3",
                   display: "flex",
                   alignItems: "center",
                   justifyContent: "center",
                   overflow: "hidden",
+                  p: 2,
                 }}
               >
-                <CardMedia
-                  component="img"
-                  image={
-                    item.image ||
-                    "https://placehold.co/400x300/1a1a1a/666666?text=Coming+Soon"
-                  }
-                  alt={item.name}
-                  sx={{
-                    width: "100%",
-                    height: "100%",
-                    objectFit: "contain",
-                  }}
-                />
+                {item.image ? (
+                  <Box
+                    component="img"
+                    src={item.image}
+                    alt={item.name}
+                    sx={{ width: "100%", height: "100%", objectFit: "contain" }}
+                  />
+                ) : (
+                  <Typography
+                    sx={{ ...NB_MONO_SX, fontSize: 11, color: NB_COLORS.steel }}
+                  >
+                    IMAGE COMING SOON
+                  </Typography>
+                )}
               </Box>
-              <CardContent
+
+              {/* Spec sheet */}
+              <Box sx={{ px: { xs: 2.5, md: 3 }, py: 2, flexGrow: 1 }}>
+                <Typography
+                  sx={{ ...NB_MONO_SX, fontSize: 11, color: NB_COLORS.steel, mb: 1 }}
+                >
+                  ITEM {String(i + 1).padStart(2, "0")} · {item.category.toUpperCase()}
+                </Typography>
+                <Typography
+                  component="h3"
+                  sx={{
+                    ...NB_DISPLAY_SX,
+                    fontSize: { xs: 16, md: 18 },
+                    color: NB_COLORS.ink,
+                  }}
+                >
+                  {item.name}
+                </Typography>
+              </Box>
+
+              {/* Terms strip */}
+              <Box
                 sx={{
+                  px: { xs: 2.5, md: 3 },
+                  py: 1,
+                  borderTop: NB_RULE,
                   display: "flex",
-                  flexDirection: "column",
-                  justifyContent: "center",
-                  textAlign: "center",
+                  justifyContent: "space-between",
+                  gap: 1,
                 }}
               >
-                <Typography
-                  variant="h6"
-                  component="h3"
-                  gutterBottom
-                  sx={{ color: "white" }}
-                >
-                  {item.name.toUpperCase()}
+                <Typography sx={{ ...NB_MONO_SX, fontSize: 10, color: NB_COLORS.steel }}>
+                  MIN RENTAL
                 </Typography>
                 <Typography
-                  variant="body2"
-                  sx={{
-                    fontSize: "12px",
-                    color: "#E5C767",
-                  }}
-                  gutterBottom
+                  sx={{ ...NB_MONO_SX, fontSize: 10, fontWeight: 700, color: NB_COLORS.ink }}
                 >
-                  {item.category.toUpperCase()}
+                  1 WEEK
                 </Typography>
-              </CardContent>
-            </Card>
-          </Grid>
-        ))}
-      </Grid>
+              </Box>
+            </Box>
+          ))}
+        </Box>
+      </Box>
     </Box>
   );
 }

--- a/app/components/SocialProofBar.tsx
+++ b/app/components/SocialProofBar.tsx
@@ -3,6 +3,12 @@
 import { useRef, useEffect, useState } from "react";
 import { Box, Typography } from "@mui/material";
 import { useInView } from "framer-motion";
+import {
+  NB_COLORS,
+  NB_DISPLAY_SX,
+  NB_MONO_SX,
+  NB_RULE,
+} from "@/lib/theme";
 
 function AnimatedNumber({
   target,
@@ -39,10 +45,9 @@ function AnimatedNumber({
     <Typography
       component="span"
       sx={{
-        fontSize: { xs: "28px", sm: "36px", md: "44px" },
-        fontWeight: 800,
-        color: "white",
-        lineHeight: 1,
+        ...NB_DISPLAY_SX,
+        fontSize: { xs: 40, sm: 52, md: 64 },
+        color: NB_COLORS.ink,
       }}
     >
       {prefix}
@@ -53,10 +58,10 @@ function AnimatedNumber({
 }
 
 const stats = [
-  { label: "Projects\nDelivered", prefix: "", target: 100, suffix: "+" },
-  { label: "Views on Our\nSet Builds", prefix: "", target: 19, suffix: "M+" },
-  { label: "Brands\nServed", prefix: "", target: 100, suffix: "+" },
-  { label: "Avg\nTurnaround", prefix: "", target: 14, suffix: " DAYS" },
+  { label: "PROJECTS DELIVERED", prefix: "", target: 100, suffix: "+" },
+  { label: "VIEWS ON OUR SET BUILDS", prefix: "", target: 19, suffix: "M+" },
+  { label: "BRANDS SERVED", prefix: "", target: 100, suffix: "+" },
+  { label: "AVG TURNAROUND, DAYS", prefix: "", target: 14, suffix: "" },
 ];
 
 export default function SocialProofBar() {
@@ -69,28 +74,30 @@ export default function SocialProofBar() {
       ref={ref}
       sx={{
         width: "100%",
-        maxWidth: "1200px",
-        mx: "auto",
-        px: { xs: 2, md: 4 },
-        py: { xs: 4, md: 6 },
+        bgcolor: NB_COLORS.paper,
+        borderBottom: NB_RULE,
       }}
     >
       <Box
         sx={{
           display: "grid",
           gridTemplateColumns: { xs: "repeat(2, 1fr)", md: "repeat(4, 1fr)" },
-          gap: { xs: 3, md: 4 },
-          textAlign: "center",
-          py: { xs: 3, md: 4 },
-          px: { xs: 2, md: 4 },
-          borderRadius: "16px",
-          border: "1px solid rgba(229,199,103,0.15)",
-          background:
-            "linear-gradient(135deg, rgba(229,199,103,0.04) 0%, rgba(0,0,0,0) 100%)",
         }}
       >
-        {stats.map((stat) => (
-          <Box key={stat.label}>
+        {stats.map((stat, i) => (
+          <Box
+            key={stat.label}
+            sx={{
+              px: { xs: 2, md: 4 },
+              py: { xs: 3, md: 5 },
+              borderRight: {
+                xs: i % 2 === 0 ? NB_RULE : "none",
+                md: i < stats.length - 1 ? NB_RULE : "none",
+              },
+              borderBottom: { xs: i < 2 ? NB_RULE : "none", md: "none" },
+              bgcolor: i % 2 === 1 ? NB_COLORS.silverLight : NB_COLORS.paper,
+            }}
+          >
             <AnimatedNumber
               target={stat.target}
               suffix={stat.suffix}
@@ -99,13 +106,11 @@ export default function SocialProofBar() {
             />
             <Typography
               sx={{
-                mt: 0.5,
-                fontSize: { xs: "11px", sm: "13px" },
-                color: "rgba(255,255,255,0.6)",
-                letterSpacing: "0.08em",
-                fontWeight: 600,
-                textTransform: "uppercase",
-                whiteSpace: "pre-line",
+                ...NB_MONO_SX,
+                mt: 1,
+                fontSize: { xs: 10, sm: 12 },
+                color: NB_COLORS.steel,
+                fontWeight: 500,
               }}
             >
               {stat.label}
@@ -113,17 +118,19 @@ export default function SocialProofBar() {
           </Box>
         ))}
       </Box>
-      <Typography
+      <Box
         sx={{
-          mt: 2.5,
-          textAlign: "center",
-          fontSize: { xs: "12px", sm: "14px" },
-          color: "rgba(255,255,255,0.5)",
-          letterSpacing: "0.06em",
+          borderTop: NB_RULE,
+          px: { xs: 2, md: 4 },
+          py: 1,
         }}
       >
-        As seen in Forbes, Rolling Stone &amp; Business Insider
-      </Typography>
+        <Typography
+          sx={{ ...NB_MONO_SX, fontSize: { xs: 10, md: 11 }, color: NB_COLORS.steel }}
+        >
+          AS SEEN IN FORBES, ROLLING STONE + BUSINESS INSIDER
+        </Typography>
+      </Box>
     </Box>
   );
 }

--- a/app/components/Specialties.tsx
+++ b/app/components/Specialties.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import Link from "next/link";
+import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
+import { Box, Typography } from "@mui/material";
+import {
+  NB_COLORS,
+  NB_DISPLAY_SX,
+  NB_MONO_SX,
+  NB_OUTLINE_TEXT_SX,
+  NB_RULE,
+} from "@/lib/theme";
+
+const SPECIALTIES = [
+  {
+    index: "S.01",
+    title: "PODCAST STUDIOS",
+    href: "/podcast-studios",
+    buyer: "FOR PODCASTERS + NETWORKS",
+    proof: "20M+ VIEWS SHOT ON OUR BUILDS",
+    copy: "Permanent, camera-ready studios designed and fabricated around your show. Acoustics, lighting, and a set your audience remembers.",
+  },
+  {
+    index: "S.02",
+    title: "BRAND ACTIVATIONS",
+    href: "/brand-activations",
+    buyer: "FOR CMOS + BRAND TEAMS",
+    proof: "TRUSTED BY GOOGLE · FEATURED IN FORBES",
+    copy: "Pop-ups, photo moments, and launch campaigns. Concept to strike, fabricated in-house and installed on your timeline.",
+  },
+];
+
+export default function Specialties() {
+  return (
+    <Box component="section" sx={{ bgcolor: NB_COLORS.paper, borderBottom: NB_RULE }}>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "baseline",
+          justifyContent: "space-between",
+          px: { xs: 3, md: 6 },
+          py: { xs: 3, md: 4 },
+          borderBottom: NB_RULE,
+          flexWrap: "wrap",
+          gap: 1,
+        }}
+      >
+        <Typography
+          variant="h2"
+          sx={{
+            ...NB_DISPLAY_SX,
+            fontSize: { xs: 32, sm: 48, lg: 64 },
+            color: NB_COLORS.ink,
+          }}
+        >
+          WHAT DO YOU NEED BUILT?
+        </Typography>
+        <Typography sx={{ ...NB_MONO_SX, fontSize: 12, color: NB_COLORS.steel }}>
+          TWO SPECIALTIES · ONE SHOP
+        </Typography>
+      </Box>
+
+      <Box
+        sx={{
+          display: "grid",
+          gridTemplateColumns: { xs: "1fr", md: "1fr 1fr" },
+        }}
+      >
+        {SPECIALTIES.map((spec, i) => (
+          <Box
+            key={spec.href}
+            component={Link}
+            href={spec.href}
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              gap: 2,
+              px: { xs: 3, md: 6 },
+              py: { xs: 4, md: 6 },
+              borderRight: { md: i === 0 ? NB_RULE : "none" },
+              borderBottom: { xs: i === 0 ? NB_RULE : "none", md: "none" },
+              textDecoration: "none",
+              color: NB_COLORS.ink,
+              "&:hover": {
+                bgcolor: NB_COLORS.ink,
+                color: NB_COLORS.paperOnInk,
+                "& .spec-outline": {
+                  WebkitTextStroke: `2px ${NB_COLORS.paperOnInk}`,
+                },
+                "& .spec-muted": { color: NB_COLORS.mutedOnInk },
+                "& .spec-arrow": { transform: "translateX(8px)" },
+              },
+            }}
+          >
+            <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "baseline" }}>
+              <Typography
+                className="spec-muted"
+                sx={{ ...NB_MONO_SX, fontSize: 12, color: NB_COLORS.steel }}
+              >
+                {spec.index} · {spec.buyer}
+              </Typography>
+            </Box>
+            <Typography
+              className="spec-outline"
+              sx={{
+                ...NB_OUTLINE_TEXT_SX,
+                fontSize: { xs: 36, sm: 48, lg: 60 },
+              }}
+            >
+              {spec.title}
+            </Typography>
+            <Typography sx={{ fontSize: { xs: 14, md: 16 }, color: "inherit", maxWidth: 480 }}>
+              {spec.copy}
+            </Typography>
+            <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mt: "auto", pt: 1 }}>
+              <Typography
+                sx={{ ...NB_MONO_SX, fontSize: 12, fontWeight: 700, color: "inherit" }}
+              >
+                {spec.proof}
+              </Typography>
+              <ArrowForwardIcon
+                className="spec-arrow"
+                sx={{ fontSize: 28, color: "inherit", transition: "transform 150ms ease" }}
+              />
+            </Box>
+          </Box>
+        ))}
+      </Box>
+
+      {/* Sunset services: available for the right project, not promoted */}
+      <Box
+        sx={{
+          borderTop: NB_RULE,
+          px: { xs: 3, md: 6 },
+          py: 1.25,
+          display: "flex",
+          justifyContent: "space-between",
+          flexWrap: "wrap",
+          gap: 1,
+        }}
+      >
+        <Typography sx={{ ...NB_MONO_SX, fontSize: 11, color: NB_COLORS.steel }}>
+          ALSO ON FILE: SET DESIGN · MUSIC VIDEOS
+        </Typography>
+        <Typography
+          component={Link}
+          href="/#contact"
+          sx={{
+            ...NB_MONO_SX,
+            fontSize: 11,
+            color: NB_COLORS.steel,
+            textDecoration: "underline",
+            textUnderlineOffset: 3,
+            "&:hover": { color: NB_COLORS.ink },
+          }}
+        >
+          FOR THE RIGHT PROJECT, ASK →
+        </Typography>
+      </Box>
+    </Box>
+  );
+}

--- a/app/components/TrustWall.tsx
+++ b/app/components/TrustWall.tsx
@@ -2,6 +2,13 @@
 
 import { Box, Typography } from "@mui/material";
 import Image from "next/image";
+import ArrowOutwardIcon from "@mui/icons-material/ArrowOutward";
+import {
+  NB_COLORS,
+  NB_DISPLAY_SX,
+  NB_MONO_SX,
+  NB_RULE,
+} from "@/lib/theme";
 
 const S3 = "https://dripdome-site.s3.us-east-2.amazonaws.com/nu_logo";
 
@@ -22,7 +29,7 @@ const pressLinks = [
   },
   {
     outlet: "Forbes",
-    headline: "Best Canned Cocktail — Original Southside",
+    headline: "Best Canned Cocktail, Original Southside",
     url: "https://www.forbes.com/sites/karlaalindahao/2024/03/01/best-canned-cocktail-original-southside/",
   },
   {
@@ -32,115 +39,50 @@ const pressLinks = [
   },
 ];
 
-function LogoMarquee() {
-  const doubled = [...logos, ...logos];
+function LogoBelt() {
+  const strip = (key: string) => (
+    <Box
+      key={key}
+      aria-hidden={key === "b"}
+      sx={{ display: "flex", alignItems: "center", flexShrink: 0 }}
+    >
+      {logos.map((logo) => (
+        <Box
+          key={logo.alt}
+          sx={{
+            width: { xs: 120, md: 170 },
+            height: { xs: 88, md: 120 },
+            flexShrink: 0,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            borderRight: `2px solid ${NB_COLORS.mutedOnInk}`,
+            px: { xs: 2, md: 3 },
+          }}
+        >
+          <Image
+            src={logo.src}
+            alt={logo.alt}
+            width={140}
+            height={140}
+            style={{ width: "100%", height: "70%", objectFit: "contain" }}
+          />
+        </Box>
+      ))}
+    </Box>
+  );
 
   return (
-    <Box
-      sx={{
-        overflow: "hidden",
-        width: "100%",
-        maskImage:
-          "linear-gradient(to right, transparent 0%, black 10%, black 90%, transparent 100%)",
-        WebkitMaskImage:
-          "linear-gradient(to right, transparent 0%, black 10%, black 90%, transparent 100%)",
-      }}
-    >
+    <Box sx={{ overflow: "hidden", display: "flex", bgcolor: NB_COLORS.well }}>
       <Box
         sx={{
           display: "flex",
-          gap: { xs: 4, md: 6 },
           width: "max-content",
-          animation: "marquee-logos 30s linear infinite",
-          alignItems: "center",
+          animation: "nb-ticker 24s linear infinite",
         }}
       >
-        {doubled.map((logo, i) => (
-          <Box
-            key={i}
-            sx={{
-              width: { xs: 80, sm: 110, md: 140 },
-              height: { xs: 80, sm: 110, md: 140 },
-              flexShrink: 0,
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              opacity: 0.7,
-              transition: "opacity 0.3s",
-              "&:hover": { opacity: 1 },
-            }}
-          >
-            <Image
-              src={logo.src}
-              alt={logo.alt}
-              width={140}
-              height={140}
-              style={{ width: "100%", height: "100%", objectFit: "contain" }}
-            />
-          </Box>
-        ))}
-      </Box>
-    </Box>
-  );
-}
-
-export function TrustPress() {
-  return (
-    <Box
-      component="section"
-      sx={{
-        width: "100%",
-        py: { xs: 5, md: 8 },
-        px: { xs: 2, md: 4 },
-      }}
-    >
-      <Box sx={{ maxWidth: 900, mx: "auto" }}>
-        <Typography
-          sx={{
-            fontSize: { xs: "24px", sm: "40px", lg: "50px" },
-            fontWeight: "bold",
-            color: "white",
-            textAlign: "center",
-            mb: { xs: 2, md: 3 },
-          }}
-        >
-          In the Press
-        </Typography>
-        <Box
-          sx={{
-            display: "flex",
-            flexDirection: "column",
-            gap: 1.5,
-            alignItems: "center",
-          }}
-        >
-          {pressLinks.map((item) => (
-            <Typography
-              key={item.url}
-              component="a"
-              href={item.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              sx={{
-                color: "rgba(255,255,255,0.6)",
-                fontSize: { xs: "14px", sm: "16px", md: "18px" },
-                textDecoration: "none",
-                letterSpacing: "0.04em",
-                transition: "color 0.2s",
-                "&:hover": { color: "#E5C767" },
-              }}
-            >
-              <Box
-                component="span"
-                sx={{ fontWeight: 700, color: "rgba(255,255,255,0.85)" }}
-              >
-                {item.outlet}
-              </Box>
-              {" — "}
-              {item.headline}
-            </Typography>
-          ))}
-        </Box>
+        {strip("a")}
+        {strip("b")}
       </Box>
     </Box>
   );
@@ -150,26 +92,130 @@ export default function TrustWall() {
   return (
     <Box
       component="section"
-      sx={{
-        width: "100%",
-        py: { xs: 5, md: 8 },
-        px: { xs: 2, md: 4 },
-      }}
+      sx={{ bgcolor: NB_COLORS.ink, borderBottom: NB_RULE }}
     >
-      <Typography
-        variant="h2"
+      <Box
         sx={{
-          fontSize: { xs: "24px", sm: "40px", lg: "50px" },
-          fontWeight: "bold",
-          color: "white",
-          textAlign: "center",
-          mb: { xs: 3, md: 5 },
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          px: { xs: 3, md: 6 },
+          py: 1.25,
+          borderBottom: `2px solid ${NB_COLORS.mutedOnInk}`,
         }}
       >
-        Trusted By
-      </Typography>
+        <Typography
+          variant="h2"
+          sx={{
+            ...NB_MONO_SX,
+            fontSize: 12,
+            fontWeight: 700,
+            color: NB_COLORS.paperOnInk,
+          }}
+        >
+          TRUSTED BY
+        </Typography>
+        <Typography sx={{ ...NB_MONO_SX, fontSize: 12, color: NB_COLORS.mutedOnInk }}>
+          WORLD-CLASS BRANDS + A-LIST TALENT
+        </Typography>
+      </Box>
+      <LogoBelt />
+    </Box>
+  );
+}
 
-      <LogoMarquee />
+export function TrustPress() {
+  return (
+    <Box
+      component="section"
+      sx={{ bgcolor: NB_COLORS.paper, borderBottom: NB_RULE }}
+    >
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "baseline",
+          justifyContent: "space-between",
+          px: { xs: 3, md: 6 },
+          py: { xs: 3, md: 4 },
+          borderBottom: NB_RULE,
+          flexWrap: "wrap",
+          gap: 1,
+        }}
+      >
+        <Typography
+          variant="h2"
+          sx={{
+            ...NB_DISPLAY_SX,
+            fontSize: { xs: 32, sm: 48, lg: 64 },
+            color: NB_COLORS.ink,
+          }}
+        >
+          IN THE PRESS
+        </Typography>
+        <Typography sx={{ ...NB_MONO_SX, fontSize: 12, color: NB_COLORS.steel }}>
+          PRESS INDEX · EXTERNAL LINKS
+        </Typography>
+      </Box>
+
+      {pressLinks.map((item, i) => (
+        <Box
+          key={item.url}
+          component="a"
+          href={item.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          sx={{
+            display: "grid",
+            gridTemplateColumns: { xs: "auto 1fr auto", md: "80px 240px 1fr auto" },
+            alignItems: "center",
+            gap: { xs: 2, md: 3 },
+            px: { xs: 3, md: 6 },
+            py: { xs: 2, md: 2.5 },
+            borderBottom: i < pressLinks.length - 1 ? NB_RULE : "none",
+            textDecoration: "none",
+            color: NB_COLORS.ink,
+            "&:hover": {
+              bgcolor: NB_COLORS.ink,
+              color: NB_COLORS.paperOnInk,
+              "& .press-meta": { color: NB_COLORS.mutedOnInk },
+            },
+          }}
+        >
+          <Typography
+            className="press-meta"
+            sx={{ ...NB_MONO_SX, fontSize: 12, color: NB_COLORS.steel }}
+          >
+            P.{String(i + 1).padStart(2, "0")}
+          </Typography>
+          <Typography
+            sx={{
+              ...NB_MONO_SX,
+              fontSize: { xs: 12, md: 14 },
+              fontWeight: 700,
+              color: "inherit",
+            }}
+          >
+            {item.outlet}
+          </Typography>
+          <Typography
+            sx={{
+              fontSize: { xs: 14, md: 17 },
+              color: "inherit",
+              gridColumn: { xs: "2 / 4", md: "auto" },
+            }}
+          >
+            {item.headline}
+          </Typography>
+          <ArrowOutwardIcon
+            sx={{
+              fontSize: 20,
+              color: "inherit",
+              display: { xs: "none", md: "block" },
+              justifySelf: "end",
+            }}
+          />
+        </Box>
+      ))}
     </Box>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -102,6 +102,21 @@ body {
   margin: 0;
 }
 
+/* Neobrutalist ticker: content is rendered twice, track slides one copy */
+@keyframes nb-ticker {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-50%);
+  }
+}
+
+::selection {
+  background: #c7cad0;
+  color: #131313;
+}
+
 @layer base {
   .theme {
     --animate-marquee: marquee var(--duration) infinite linear;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from "next";
-import { Source_Sans_3 } from "next/font/google";
+import { Source_Sans_3, Archivo_Black, IBM_Plex_Mono } from "next/font/google";
 import Script from "next/script";
 import "./globals.css";
 import ClientLayout from "./ClientLayout";
@@ -13,6 +13,20 @@ const sourceSans = Source_Sans_3({
   subsets: ["latin"],
   display: "swap",
   variable: "--font-source-sans",
+});
+
+const archivoBlack = Archivo_Black({
+  subsets: ["latin"],
+  weight: "400",
+  display: "swap",
+  variable: "--font-display",
+});
+
+const plexMono = IBM_Plex_Mono({
+  subsets: ["latin"],
+  weight: ["400", "500", "700"],
+  display: "swap",
+  variable: "--font-mono",
 });
 
 export const metadata: Metadata = {
@@ -78,7 +92,10 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={sourceSans.variable}>
+    <html
+      lang="en"
+      className={`${sourceSans.variable} ${archivoBlack.variable} ${plexMono.variable}`}
+    >
       <head>
         <Script
           id="google-ads-gtag"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,9 @@
 import { Box } from "@mui/material";
 import type { Metadata } from "next";
+import { NB_COLORS } from "@/lib/theme";
 import HomeHero from "./components/HomeHero";
 import SocialProofBar from "./components/SocialProofBar";
+import Specialties from "./components/Specialties";
 import HomeFeaturedWork from "./components/HomeFeaturedWork";
 import TrustWall, { TrustPress } from "./components/TrustWall";
 import OurServices from "./components/OurServices";
@@ -50,9 +52,10 @@ export const metadata: Metadata = {
 
 export default function Home() {
   return (
-    <Box component="main" sx={{ bgcolor: "black", color: "common.white" }}>
+    <Box component="main" sx={{ bgcolor: NB_COLORS.paper, color: NB_COLORS.ink }}>
       <HomeHero />
       <SocialProofBar />
+      <Specialties />
       <HomeFeaturedWork />
       <TrustWall />
       {/* <OurServices /> */}

--- a/app/podcast-studios/PodcastStudiosHero.tsx
+++ b/app/podcast-studios/PodcastStudiosHero.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import { Box, Button, Typography } from "@mui/material";
+import Link from "next/link";
+import { motion } from "framer-motion";
+import {
+  NB_BUTTON_OUTLINE_SX,
+  NB_BUTTON_SX,
+  NB_COLORS,
+  NB_DISPLAY_SX,
+  NB_MONO_SX,
+  NB_OUTLINE_TEXT_SX,
+  NB_RULE,
+} from "@/lib/theme";
+
+const PROOF = [
+  { value: "20M+", label: "VIEWS SHOT ON OUR BUILDS" },
+  { value: "230K+", label: "SUBSCRIBERS ON THE FLAGSHIP SET" },
+  { value: "65+", label: "EPISODES AND COUNTING" },
+  { value: "4 DAYS", label: "FASTEST FULL BUILD" },
+];
+
+const SPECS = [
+  {
+    index: "A",
+    title: "CAMERA-READY DESIGN",
+    copy: "Backdrops composed for your framing, not an empty room with chairs.",
+  },
+  {
+    index: "B",
+    title: "CINEMATIC LIGHTING",
+    copy: "Key, fill, and practicals planned into the build, no fix-it-in-post.",
+  },
+  {
+    index: "C",
+    title: "CUSTOM DESKS + SEATING",
+    copy: "Fabricated to your show's format: solo, panel, or face-to-face.",
+  },
+  {
+    index: "D",
+    title: "LED + NEON SIGNAGE",
+    copy: "Hand wired statement pieces, like the NotLoveline heart wall.",
+  },
+  {
+    index: "E",
+    title: "TECH + CABLE INTEGRATION",
+    copy: "Cameras, mics, and monitors wired clean and hidden from lens view.",
+  },
+  {
+    index: "F",
+    title: "SPONSOR-READY MOMENTS",
+    copy: "Set zones designed to carry brand integrations without breaking the look.",
+  },
+];
+
+export default function PodcastStudiosHero() {
+  return (
+    <>
+      {/* Hero */}
+      <Box component="section" sx={{ bgcolor: NB_COLORS.paper, borderBottom: NB_RULE }}>
+        <Box sx={{ px: { xs: 3, md: 6 }, py: { xs: 5, md: 8 }, maxWidth: 1440, mx: "auto" }}>
+          <motion.div
+            initial={{ opacity: 0, y: 16 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5 }}
+          >
+            <Typography sx={{ ...NB_MONO_SX, fontSize: 12, color: NB_COLORS.steel, mb: 2 }}>
+              SPECIALTY 01 · PODCAST STUDIO DESIGN + BUILD · NYC + LA
+            </Typography>
+          </motion.div>
+
+          <motion.div
+            initial={{ opacity: 0, y: 24 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.1 }}
+          >
+            <Typography
+              variant="h1"
+              sx={{
+                ...NB_DISPLAY_SX,
+                fontSize: { xs: 44, sm: 64, md: 80, lg: 96 },
+                color: NB_COLORS.ink,
+                mb: 3,
+              }}
+            >
+              YOUR SHOW
+              <Box component="span" sx={{ ...NB_OUTLINE_TEXT_SX, display: "block" }}>
+                DESERVES A SET.
+              </Box>
+            </Typography>
+          </motion.div>
+
+          <motion.div
+            initial={{ opacity: 0, y: 16 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.25 }}
+          >
+            <Typography
+              sx={{ fontSize: { xs: 16, md: 18 }, color: NB_COLORS.ink, maxWidth: 640, mb: 4 }}
+            >
+              Permanent, camera-ready podcast studios designed, fabricated, and
+              wired in-house. Your audience judges the room before they judge
+              the conversation. We build rooms that win that judgment.
+            </Typography>
+            <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
+              <Button
+                component={Link}
+                href="#contact"
+                disableElevation
+                sx={{ ...NB_BUTTON_SX, px: 4, py: 1.5, fontSize: { xs: 13, md: 14 } }}
+              >
+                START YOUR BUILD
+              </Button>
+              <Button
+                component={Link}
+                href="#builds"
+                disableElevation
+                sx={{ ...NB_BUTTON_OUTLINE_SX, px: 4, py: 1.5, fontSize: { xs: 13, md: 14 } }}
+              >
+                SEE A BUILD
+              </Button>
+            </Box>
+          </motion.div>
+        </Box>
+
+        {/* Proof band */}
+        <Box
+          sx={{
+            borderTop: NB_RULE,
+            display: "grid",
+            gridTemplateColumns: { xs: "repeat(2, 1fr)", md: "repeat(4, 1fr)" },
+          }}
+        >
+          {PROOF.map((stat, i) => (
+            <Box
+              key={stat.label}
+              sx={{
+                px: { xs: 2, md: 4 },
+                py: { xs: 2.5, md: 4 },
+                borderRight: {
+                  xs: i % 2 === 0 ? NB_RULE : "none",
+                  md: i < PROOF.length - 1 ? NB_RULE : "none",
+                },
+                borderBottom: { xs: i < 2 ? NB_RULE : "none", md: "none" },
+                bgcolor: i % 2 === 1 ? NB_COLORS.silverLight : NB_COLORS.paper,
+              }}
+            >
+              <Typography
+                sx={{ ...NB_DISPLAY_SX, fontSize: { xs: 32, md: 48 }, color: NB_COLORS.ink }}
+              >
+                {stat.value}
+              </Typography>
+              <Typography
+                sx={{ ...NB_MONO_SX, mt: 1, fontSize: { xs: 10, sm: 11 }, color: NB_COLORS.steel }}
+              >
+                {stat.label}
+              </Typography>
+            </Box>
+          ))}
+        </Box>
+      </Box>
+
+      {/* Build spec sheet */}
+      <Box component="section" sx={{ bgcolor: NB_COLORS.paper, borderBottom: NB_RULE }}>
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "baseline",
+            justifyContent: "space-between",
+            px: { xs: 3, md: 6 },
+            py: { xs: 3, md: 4 },
+            borderBottom: NB_RULE,
+            flexWrap: "wrap",
+            gap: 1,
+          }}
+        >
+          <Typography
+            variant="h2"
+            sx={{ ...NB_DISPLAY_SX, fontSize: { xs: 32, sm: 48, lg: 64 }, color: NB_COLORS.ink }}
+          >
+            WHAT&apos;S IN A BUILD
+          </Typography>
+          <Typography sx={{ ...NB_MONO_SX, fontSize: 12, color: NB_COLORS.steel }}>
+            STANDARD SPEC · EVERY STUDIO
+          </Typography>
+        </Box>
+        <Box
+          sx={{
+            display: "grid",
+            gridTemplateColumns: { xs: "1fr", sm: "1fr 1fr", md: "repeat(3, 1fr)" },
+          }}
+        >
+          {SPECS.map((spec, i) => (
+            <Box
+              key={spec.index}
+              sx={{
+                px: { xs: 3, md: 4 },
+                py: { xs: 3, md: 4 },
+                borderRight: {
+                  sm: i % 2 === 0 ? NB_RULE : "none",
+                  md: (i + 1) % 3 !== 0 ? NB_RULE : "none",
+                },
+                borderBottom: {
+                  xs: i < SPECS.length - 1 ? NB_RULE : "none",
+                  sm: i < SPECS.length - 2 ? NB_RULE : "none",
+                  md: i < SPECS.length - 3 ? NB_RULE : "none",
+                },
+              }}
+            >
+              <Typography sx={{ ...NB_MONO_SX, fontSize: 12, color: NB_COLORS.steel, mb: 1.5 }}>
+                SPEC {spec.index}
+              </Typography>
+              <Typography
+                sx={{ ...NB_DISPLAY_SX, fontSize: { xs: 17, md: 20 }, color: NB_COLORS.ink, mb: 1 }}
+              >
+                {spec.title}
+              </Typography>
+              <Typography sx={{ fontSize: { xs: 14, md: 15 }, color: NB_COLORS.steel }}>
+                {spec.copy}
+              </Typography>
+            </Box>
+          ))}
+        </Box>
+      </Box>
+    </>
+  );
+}

--- a/app/podcast-studios/PodcastStudiosJsonLd.tsx
+++ b/app/podcast-studios/PodcastStudiosJsonLd.tsx
@@ -1,0 +1,25 @@
+export default function PodcastStudiosJsonLd() {
+  const schema = {
+    "@context": "https://schema.org",
+    "@type": "Service",
+    name: "Podcast Studio Design and Build",
+    serviceType: "Podcast Studio Fabrication",
+    description:
+      "Turnkey podcast studio builder. Studio design, custom fabrication, lighting, and wiring, all in house. Permanent camera-ready podcast sets in NYC and LA.",
+    url: "https://www.dripdome.com/podcast-studios",
+    areaServed: ["New York City", "Manhattan", "Brooklyn", "Los Angeles"],
+    provider: {
+      "@type": "LocalBusiness",
+      "@id": "https://www.dripdome.com",
+      name: "DripDome",
+      url: "https://www.dripdome.com",
+    },
+  };
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+    />
+  );
+}

--- a/app/podcast-studios/page.tsx
+++ b/app/podcast-studios/page.tsx
@@ -1,0 +1,95 @@
+import { Box } from "@mui/material";
+import type { Metadata } from "next";
+import JobFile from "../components/JobFile";
+import HowWeWork from "../components/HowWeWork";
+import Contact from "../components/Contact";
+import PodcastStudiosHero from "./PodcastStudiosHero";
+import PodcastStudiosJsonLd from "./PodcastStudiosJsonLd";
+import { projectsByVertical } from "@/lib/projects";
+import { NB_COLORS, NB_DISPLAY_SX, NB_MONO_SX, NB_RULE } from "@/lib/theme";
+import { Typography } from "@mui/material";
+
+export const metadata: Metadata = {
+  title: "Podcast Studio Design & Build - NYC & LA | DripDome",
+  description:
+    "DripDome designs and builds permanent, camera-ready podcast studios in NYC & LA. Custom fabrication, lighting, LED signage & full wiring. Our builds have 20M+ views. Built in as little as 4 days.",
+  keywords:
+    "podcast studio builders, podcast studio design, podcast set design, custom podcast studio NYC, podcast studio build LA, podcast set fabrication, camera-ready studio, podcast studio construction",
+  openGraph: {
+    title: "Podcast Studio Design & Build - NYC & LA | DripDome",
+    description:
+      "Permanent, camera-ready podcast studios designed, fabricated, and wired in-house. 20M+ views shot on our builds. NYC & LA.",
+    url: "https://www.dripdome.com/podcast-studios",
+    type: "website",
+    locale: "en_US",
+    siteName: "DripDome",
+    images: [
+      {
+        url: "https://dripdome-site.s3.us-east-2.amazonaws.com/NLL/IMG_1.JPG",
+        width: 1200,
+        height: 630,
+        alt: "DripDome custom podcast studio build for NotLoveline",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Podcast Studio Design & Build - NYC & LA | DripDome",
+    description:
+      "Permanent, camera-ready podcast studios designed, fabricated, and wired in-house. 20M+ views shot on our builds.",
+    images: ["https://dripdome-site.s3.us-east-2.amazonaws.com/NLL/IMG_1.JPG"],
+  },
+  alternates: {
+    canonical: "https://www.dripdome.com/podcast-studios",
+  },
+};
+
+export default function PodcastStudiosPage() {
+  const builds = projectsByVertical("podcast");
+
+  return (
+    <Box component="main" sx={{ bgcolor: NB_COLORS.paper, color: NB_COLORS.ink }}>
+      <PodcastStudiosJsonLd />
+      <PodcastStudiosHero />
+
+      {/* Shipped builds */}
+      <Box
+        component="section"
+        id="builds"
+        sx={{ bgcolor: NB_COLORS.paper, borderBottom: NB_RULE, scrollMarginTop: "120px" }}
+      >
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "baseline",
+            justifyContent: "space-between",
+            px: { xs: 3, md: 6 },
+            py: { xs: 3, md: 4 },
+            borderBottom: NB_RULE,
+            flexWrap: "wrap",
+            gap: 1,
+          }}
+        >
+          <Typography
+            variant="h2"
+            sx={{ ...NB_DISPLAY_SX, fontSize: { xs: 32, sm: 48, lg: 64 }, color: NB_COLORS.ink }}
+          >
+            SHIPPED BUILDS
+          </Typography>
+          <Typography sx={{ ...NB_MONO_SX, fontSize: 12, color: NB_COLORS.steel }}>
+            PODCAST FILES · FROM THE ARCHIVE
+          </Typography>
+        </Box>
+        {builds.map((project) => (
+          <JobFile key={project.slug} project={project} />
+        ))}
+      </Box>
+
+      <HowWeWork />
+
+      <Box id="contact" sx={{ scrollMarginTop: { xs: 95, md: 120 } }}>
+        <Contact />
+      </Box>
+    </Box>
+  );
+}

--- a/app/portfolio/PortfolioContent.tsx
+++ b/app/portfolio/PortfolioContent.tsx
@@ -1,59 +1,73 @@
 "use client";
 
-import { Box, Container, Typography } from "@mui/material";
+import { Box, Typography } from "@mui/material";
+import { motion } from "framer-motion";
 import PhotoPageCarousels from "../components/PhotoPageCarousels";
 import Contact from "../components/Contact";
-import { motion } from "framer-motion";
 import FeaturedProjects from "../components/FeaturedProjects";
 import PressSection from "../components/PressSection";
-import { BRAND_GRADIENT_TEXT_SX } from "@/lib/theme";
+import {
+  NB_COLORS,
+  NB_DISPLAY_SX,
+  NB_MONO_SX,
+  NB_OUTLINE_TEXT_SX,
+  NB_RULE,
+} from "@/lib/theme";
 
 export default function PortfolioContent() {
   return (
     <Box
+      component="main"
       sx={{
         minHeight: "100vh",
         width: "100%",
-        bgcolor: "black",
-        px: 2,
-        pt: { xs: 8, md: 6 },
-        overflowX: "hidden",
+        bgcolor: NB_COLORS.paper,
+        color: NB_COLORS.ink,
       }}
     >
-      <Container maxWidth="lg" sx={{ px: { xs: 2, md: 4 } }}>
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0, duration: 0.5 }}
-        >
-          <Typography
-            variant="h1"
-            component="h1"
-            color="white"
-            sx={{
-              fontSize: { xs: "45px", sm: "95px", lg: "96px" },
-              fontWeight: "bold",
-              marginBottom: { xs: "20px", md: "30px" },
-              textAlign: "center",
-            }}
+      {/* Hero */}
+      <Box component="section" sx={{ bgcolor: NB_COLORS.paper, borderBottom: NB_RULE }}>
+        <Box sx={{ px: { xs: 3, md: 6 }, py: { xs: 5, md: 8 }, maxWidth: 1440, mx: "auto" }}>
+          <motion.div
+            initial={{ opacity: 0, y: 16 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5 }}
           >
-            PORTFOLIO
-          </Typography>
-        </motion.div>
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0, duration: 1 }}
-        >
-          <Box sx={{ mx: "auto", maxWidth: "56rem", mb: { xs: 4, md: 12 } }}>
+            <Typography sx={{ ...NB_MONO_SX, fontSize: 12, color: NB_COLORS.steel, mb: 2 }}>
+              INDEX · SET DESIGN + CUSTOM FABRICATION · NYC + LA
+            </Typography>
+          </motion.div>
+
+          <motion.div
+            initial={{ opacity: 0, y: 24 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.1 }}
+          >
             <Typography
-              variant="body1"
-              component="p"
-              color="white"
+              variant="h1"
+              component="h1"
               sx={{
-                fontSize: { xs: "14px", sm: "20px", md: "24px" },
-                textAlign: "center",
+                ...NB_DISPLAY_SX,
+                fontSize: { xs: 44, sm: 72, md: 96 },
+                color: NB_COLORS.ink,
+                mb: 3,
               }}
+            >
+              PORT
+              <Box component="span" sx={{ ...NB_OUTLINE_TEXT_SX, fontSize: "inherit" }}>
+                FOLIO
+              </Box>
+            </Typography>
+          </motion.div>
+
+          <motion.div
+            initial={{ opacity: 0, y: 16 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.25 }}
+          >
+            <Typography
+              component="p"
+              sx={{ fontSize: { xs: 15, md: 18 }, color: NB_COLORS.ink, maxWidth: 720 }}
             >
               We specialize in creating unforgettable set designs and custom
               fabrications for photoshoots that demand visual excellence. From
@@ -61,71 +75,52 @@ export default function PortfolioContent() {
               stylists, and brands to craft striking, camera-ready environments
               that captivate audiences.
             </Typography>
-          </Box>
-        </motion.div>
-        <Box sx={{ mb: { xs: 4, md: 0 } }}>
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0, duration: 1 }}
-          >
-            <Box sx={{ textAlign: "center" }}>
-              <Typography
-                variant="h2"
-                component="h2"
-                color="white"
-                sx={{
-                  fontSize: { xs: "30px", sm: "55px", lg: "70px" },
-                  fontWeight: "bold",
-                  display: "inline",
-                }}
-              >
-                FEATURED{" "}
-              </Typography>
-              <Typography
-                variant="h2"
-                component="span"
-                sx={{
-                  fontSize: { xs: "30px", sm: "55px", lg: "70px" },
-                  fontWeight: "bold",
-                  ...BRAND_GRADIENT_TEXT_SX,
-                }}
-              >
-                PROJECTS
-              </Typography>
-            </Box>
           </motion.div>
         </Box>
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0, duration: 1.5 }}
-        >
-          <FeaturedProjects />
-        </motion.div>
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0, duration: 1.5 }}
-        >
-          <PhotoPageCarousels />
-        </motion.div>
+      </Box>
 
-        <Box sx={{ mt: 16 }}>
-          <PressSection />
-        </Box>
+      {/* Featured projects */}
+      <Box component="section" sx={{ bgcolor: NB_COLORS.paper, borderBottom: NB_RULE }}>
         <Box
           sx={{
-            mt: 8,
-            py: 12,
-            px: { xs: 2, md: 8 },
-            bgcolor: "black",
-            color: "white",
+            display: "flex",
+            alignItems: "baseline",
+            justifyContent: "space-between",
+            px: { xs: 3, md: 6 },
+            py: { xs: 3, md: 4 },
+            borderBottom: NB_RULE,
+            flexWrap: "wrap",
+            gap: 1,
           }}
         >
-          <Contact />
+          <Typography
+            variant="h2"
+            component="h2"
+            sx={{
+              ...NB_DISPLAY_SX,
+              fontSize: { xs: 32, sm: 48, lg: 64 },
+              color: NB_COLORS.ink,
+            }}
+          >
+            FEATURED PROJECTS
+          </Typography>
+          <Typography sx={{ ...NB_MONO_SX, fontSize: 12, color: NB_COLORS.steel }}>
+            CASE FILES · 05 PROJECTS
+          </Typography>
         </Box>
-      </Container>
+        <FeaturedProjects />
+      </Box>
+
+      {/* Photography archive */}
+      <PhotoPageCarousels />
+
+      {/* Press */}
+      <PressSection />
+
+      {/* Contact */}
+      <Box id="contact" sx={{ scrollMarginTop: { xs: 95, md: 120 } }}>
+        <Contact />
+      </Box>
     </Box>
   );
 }

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,5 +1,12 @@
 import { Metadata } from "next";
-import { Box, Container, Typography } from "@mui/material";
+import { Box, Typography } from "@mui/material";
+import Footer from "../ui/Footer";
+import {
+  NB_COLORS,
+  NB_DISPLAY_SX,
+  NB_MONO_SX,
+  NB_RULE,
+} from "@/lib/theme";
 
 export const metadata: Metadata = {
   title: "Privacy Policy | DripDome",
@@ -31,31 +38,59 @@ export const metadata: Metadata = {
 
 export default function PrivacyPolicy() {
   return (
-    <Box
-      component="main"
-      sx={{
-        bgcolor: "black",
-        minHeight: "100vh",
-        pt: { xs: 12, md: 16 },
-        pb: 8,
-      }}
-    >
-      <Container maxWidth="md" sx={{ px: { xs: 2, md: 4 } }}>
-        <Typography
-          variant="h1"
-          component="h1"
-          color="white"
+    <>
+      <Box
+        component="main"
+        sx={{ bgcolor: NB_COLORS.paper, color: NB_COLORS.ink, minHeight: "60vh" }}
+      >
+        {/* Section header */}
+        <Box
           sx={{
-            fontSize: { xs: "36px", sm: "48px", md: "56px" },
-            fontWeight: "bold",
-            mb: 4,
-            textAlign: "center",
+            display: "flex",
+            alignItems: "baseline",
+            justifyContent: "space-between",
+            px: { xs: 3, md: 6 },
+            py: { xs: 3, md: 4 },
+            borderBottom: NB_RULE,
+            flexWrap: "wrap",
+            gap: 1,
           }}
         >
-          Privacy Policy
-        </Typography>
+          <Typography
+            variant="h1"
+            component="h1"
+            sx={{
+              ...NB_DISPLAY_SX,
+              fontSize: { xs: 32, sm: 48, lg: 64 },
+              color: NB_COLORS.ink,
+            }}
+          >
+            PRIVACY POLICY
+          </Typography>
+          <Typography sx={{ ...NB_MONO_SX, fontSize: 12, color: NB_COLORS.steel }}>
+            LEGAL · DRIPDOME.COM
+          </Typography>
+        </Box>
 
-        <Box sx={{ color: "grey.300", "& > p": { mb: 3 } }}>
+        {/* Policy body */}
+        <Box
+          sx={{
+            px: { xs: 3, md: 6 },
+            py: { xs: 4, md: 6 },
+            maxWidth: 720,
+            "& > p": {
+              mb: 3,
+              fontSize: { xs: 15, md: 17 },
+              lineHeight: 1.7,
+              color: NB_COLORS.ink,
+            },
+            "& a": {
+              color: NB_COLORS.ink,
+              textDecoration: "underline",
+              textUnderlineOffset: 3,
+            },
+          }}
+        >
           <Typography variant="body1" component="p">
             Your privacy is important to us. It is our policy to respect your
             privacy regarding any information we may collect from you across our
@@ -103,14 +138,14 @@ export default function PrivacyPolicy() {
           </Typography>
 
           <Typography
-            variant="body1"
             component="p"
-            sx={{ fontStyle: "italic" }}
+            sx={{ ...NB_MONO_SX, fontSize: 12, color: NB_COLORS.steel, pt: 1 }}
           >
             This policy is effective as of January 1, 2025.
           </Typography>
         </Box>
-      </Container>
-    </Box>
+      </Box>
+      <Footer />
+    </>
   );
 }

--- a/app/rentals/RentalForm.tsx
+++ b/app/rentals/RentalForm.tsx
@@ -15,6 +15,85 @@ import {
 import { useState } from "react";
 import ReCAPTCHA from "react-google-recaptcha";
 import { rentalEquipment } from "./data";
+import {
+  FONT_MONO,
+  NB_BUTTON_SX,
+  NB_COLORS,
+  NB_DISPLAY_SX,
+  NB_MONO_SX,
+  NB_OUTLINE_TEXT_SX,
+  NB_RULE,
+  nbShadow,
+} from "@/lib/theme";
+
+const FIELD_SX = {
+  "& .MuiInputBase-root": {
+    bgcolor: NB_COLORS.surface,
+    color: NB_COLORS.ink,
+    borderRadius: 0,
+  },
+  "& .MuiOutlinedInput-notchedOutline": {
+    border: NB_RULE,
+  },
+  "& .MuiInputBase-root:hover .MuiOutlinedInput-notchedOutline": {
+    border: NB_RULE,
+  },
+  "& .MuiInputBase-root.Mui-focused .MuiOutlinedInput-notchedOutline": {
+    border: NB_RULE,
+  },
+  "& .MuiInputBase-root.Mui-focused": {
+    boxShadow: nbShadow(4),
+  },
+  "& .MuiInputBase-input::placeholder": {
+    fontFamily: FONT_MONO,
+    fontSize: 13,
+    letterSpacing: "0.08em",
+    color: NB_COLORS.steel,
+    opacity: 1,
+  },
+  "& .MuiInputLabel-root": {
+    fontFamily: FONT_MONO,
+    fontSize: 13,
+    letterSpacing: "0.08em",
+    textTransform: "uppercase",
+    color: NB_COLORS.steel,
+  },
+  "& .MuiInputLabel-root.Mui-focused": {
+    color: NB_COLORS.ink,
+  },
+  "& .MuiSvgIcon-root": {
+    color: NB_COLORS.ink,
+  },
+} as const;
+
+const MENU_PROPS = {
+  PaperProps: {
+    sx: {
+      bgcolor: NB_COLORS.surface,
+      color: NB_COLORS.ink,
+      border: NB_RULE,
+      borderRadius: 0,
+      boxShadow: nbShadow(4),
+      "& .MuiMenuItem-root": {
+        fontFamily: FONT_MONO,
+        fontSize: 13,
+        letterSpacing: "0.04em",
+      },
+      "& .MuiMenuItem-root.Mui-selected": {
+        bgcolor: NB_COLORS.silverLight,
+      },
+      "& .MuiMenuItem-root.Mui-selected:hover": {
+        bgcolor: NB_COLORS.silverLight,
+      },
+    },
+  },
+} as const;
+
+const DETAILS = [
+  { label: "MIN RENTAL PERIOD", value: "1 WEEK" },
+  { label: "PICKUP / DELIVERY", value: "NEW YORK CITY" },
+  { label: "RESPONSE TIME", value: "WITHIN 48 HOURS" },
+];
 
 export default function RentalForm() {
   const recaptchaRef = useRef<ReCAPTCHA>(null);
@@ -25,246 +104,251 @@ export default function RentalForm() {
     setSelectedEquipment(typeof value === "string" ? value.split(",") : value);
   };
 
-  const inputStyles = {
-    "& .MuiInputBase-root": { bgcolor: "white", color: "black" },
-    "& .MuiInputBase-input::placeholder": {
-      color: "rgba(0,0,0,0.7)",
-      opacity: 1,
-    },
-    "& .MuiInputLabel-root": {
-      color: "rgba(0,0,0,0.7)",
-    },
-    "& .MuiOutlinedInput-notchedOutline": {
-      borderColor: "rgba(0,0,0,0.23)",
-    },
-  };
-
   return (
-    <Box
-      sx={{
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        px: { xs: 4, md: 8 },
-        py: 6,
-      }}
-    >
-      <Typography
-        variant="h2"
-        component="h2"
-        sx={{
-          fontSize: { xs: "40px", md: "60px", lg: "70px" },
-          fontWeight: "bold",
-          marginBottom: "15px",
-          justifyContent: "center",
-          display: "flex",
-          color: "white",
-          whiteSpace: "nowrap",
-        }}
-      >
-        Request a Rental
-      </Typography>
-
-      <Typography
-        variant="body2"
-        component="p"
-        sx={{
-          fontSize: { sm: "18px", md: "22px", lg: "26px" },
-          display: "flex",
-          textAlign: "center",
-          maxWidth: 900,
-          marginBottom: "30px",
-          color: "white",
-        }}
-      >
-        Fill out the form below to request rental equipment for your production.
-        We&apos;ll get back to you shortly!
-      </Typography>
-
+    <Box component="section" sx={{ bgcolor: NB_COLORS.paper }}>
       <Box
-        component="form"
         sx={{
-          display: "flex",
-          flexDirection: "column",
-          width: "100%",
-          maxWidth: 900,
-          mx: "auto",
-          mb: 4,
-          gap: { xs: 2, md: 2.5 },
-        }}
-        onSubmit={async (e: FormEvent<HTMLFormElement>) => {
-          e.preventDefault();
-
-          const captchaValue = recaptchaRef.current?.getValue();
-          if (!captchaValue) {
-            alert("Please complete the CAPTCHA");
-            return;
-          }
-
-          const form = e.currentTarget;
-          const formElements = form.elements as HTMLFormControlsCollection & {
-            name: HTMLInputElement;
-            instagram: HTMLInputElement;
-            email: HTMLInputElement;
-            startDate: HTMLInputElement;
-            endDate: HTMLInputElement;
-            projectDescription: HTMLTextAreaElement;
-          };
-
-          const formData = {
-            recaptchaToken: captchaValue,
-            name: formElements.name.value,
-            instagram: formElements.instagram.value,
-            email: formElements.email.value,
-            equipmentDesired: selectedEquipment,
-            rentalStartDate: formElements.startDate.value,
-            rentalEndDate: formElements.endDate.value,
-            projectDescription: formElements.projectDescription.value,
-            formType: "rental", // Identify this as a rental request
-          };
-
-          try {
-            const response = await fetch("/api/contact", {
-              method: "POST",
-              headers: {
-                "Content-Type": "application/json",
-              },
-              body: JSON.stringify(formData),
-            });
-
-            if (response.ok) {
-              alert("Thank you! Your rental request has been sent.");
-              form.reset();
-              setSelectedEquipment([]);
-              recaptchaRef.current?.reset();
-            } else {
-              throw new Error("Failed to send request");
-            }
-          } catch {
-            alert("An error occurred. Please try again.");
-          }
+          display: "grid",
+          gridTemplateColumns: { xs: "1fr", md: "5fr 7fr" },
         }}
       >
-        {/* Name */}
-        <TextField
-          name="name"
-          placeholder="NAME"
-          required
-          fullWidth
-          inputProps={{ "aria-label": "Name" }}
-          sx={inputStyles}
-        />
-
-        {/* Instagram */}
-        <TextField
-          name="instagram"
-          placeholder="INSTAGRAM"
-          required
-          fullWidth
-          inputProps={{ "aria-label": "Instagram" }}
-          sx={inputStyles}
-        />
-
-        {/* Email */}
-        <TextField
-          name="email"
-          type="email"
-          placeholder="EMAIL"
-          required
-          fullWidth
-          inputProps={{ "aria-label": "Email" }}
-          sx={inputStyles}
-        />
-
-        {/* Equipment Desired - Dropdown */}
-        <FormControl
-          fullWidth
+        {/* Left: intake header */}
+        <Box
           sx={{
-            "& .MuiInputBase-root": { bgcolor: "white", color: "black" },
-            "& .MuiInputLabel-root": { color: "rgba(0,0,0,0.7)" },
-            "& .MuiInputLabel-root.Mui-focused": { color: "black" },
-            "& .MuiSelect-select": { color: "black" },
+            px: { xs: 3, md: 6 },
+            py: { xs: 4, md: 6 },
+            borderRight: { md: NB_RULE },
+            borderBottom: { xs: NB_RULE, md: "none" },
+            display: "flex",
+            flexDirection: "column",
           }}
         >
-          <InputLabel id="equipment-label">EQUIPMENT DESIRED</InputLabel>
-          <Select
-            labelId="equipment-label"
-            multiple
-            value={selectedEquipment}
-            onChange={handleEquipmentChange}
-            label="EQUIPMENT DESIRED"
-            required
-            inputProps={{ "aria-label": "Equipment Desired" }}
+          <Typography sx={{ ...NB_MONO_SX, fontSize: 12, color: NB_COLORS.steel, mb: 2 }}>
+            RENTAL INTAKE · FORM R
+          </Typography>
+          <Typography
+            variant="h2"
+            sx={{
+              ...NB_DISPLAY_SX,
+              fontSize: { xs: 40, sm: 56, lg: 72 },
+              color: NB_COLORS.ink,
+              mb: 1,
+            }}
           >
-            {rentalEquipment.map((item) => (
-              <MenuItem key={item.id} value={item.name}>
-                {item.name}
-              </MenuItem>
+            REQUEST
+          </Typography>
+          <Typography
+            sx={{
+              ...NB_OUTLINE_TEXT_SX,
+              fontSize: { xs: 40, sm: 56, lg: 72 },
+              mb: 3,
+            }}
+          >
+            A RENTAL.
+          </Typography>
+          <Typography
+            sx={{ fontSize: { xs: 15, md: 17 }, color: NB_COLORS.ink, maxWidth: 420, mb: 4 }}
+          >
+            Fill out the form below to request rental equipment for your
+            production. We&apos;ll get back to you shortly!
+          </Typography>
+
+          <Box sx={{ mt: "auto" }}>
+            {DETAILS.map((row) => (
+              <Box
+                key={row.label}
+                sx={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  gap: 2,
+                  py: 1.25,
+                  borderTop: NB_RULE,
+                }}
+              >
+                <Typography sx={{ ...NB_MONO_SX, fontSize: 11, color: NB_COLORS.steel }}>
+                  {row.label}
+                </Typography>
+                <Typography
+                  sx={{ ...NB_MONO_SX, fontSize: 11, fontWeight: 700, color: NB_COLORS.ink }}
+                >
+                  {row.value}
+                </Typography>
+              </Box>
             ))}
-          </Select>
-        </FormControl>
-
-        {/* Rental Timeframe - Start and End Date */}
-        <Box sx={{ display: "flex", gap: 2, flexDirection: { xs: "column", sm: "row" } }}>
-          <TextField
-            name="startDate"
-            type="datetime-local"
-            required
-            fullWidth
-            label="RENTAL START DATE"
-            InputLabelProps={{ shrink: true }}
-            inputProps={{ "aria-label": "Rental Start Date" }}
-            sx={inputStyles}
-          />
-          <TextField
-            name="endDate"
-            type="datetime-local"
-            required
-            fullWidth
-            label="RENTAL END DATE"
-            InputLabelProps={{ shrink: true }}
-            inputProps={{ "aria-label": "Rental End Date" }}
-            sx={inputStyles}
-          />
+          </Box>
         </Box>
 
-        {/* Project Description */}
-        <TextField
-          name="projectDescription"
-          placeholder="DESCRIPTION OF PROJECT"
-          required
-          fullWidth
-          multiline
-          minRows={4}
-          inputProps={{ "aria-label": "Project Description" }}
-          sx={inputStyles}
-        />
+        {/* Right: form */}
+        <Box sx={{ px: { xs: 3, md: 6 }, py: { xs: 4, md: 6 } }}>
+          <Box
+            component="form"
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              width: "100%",
+              maxWidth: 900,
+              mx: "auto",
+              gap: { xs: 2, md: 2.5 },
+            }}
+            onSubmit={async (e: FormEvent<HTMLFormElement>) => {
+              e.preventDefault();
 
-        {/* ReCAPTCHA */}
-        <Box sx={{ mb: 1, display: "flex", justifyContent: "center" }}>
-          <ReCAPTCHA
-            ref={recaptchaRef}
-            sitekey={process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY || ""}
-          />
+              const captchaValue = recaptchaRef.current?.getValue();
+              if (!captchaValue) {
+                alert("Please complete the CAPTCHA");
+                return;
+              }
+
+              const form = e.currentTarget;
+              const formElements = form.elements as HTMLFormControlsCollection & {
+                name: HTMLInputElement;
+                instagram: HTMLInputElement;
+                email: HTMLInputElement;
+                startDate: HTMLInputElement;
+                endDate: HTMLInputElement;
+                projectDescription: HTMLTextAreaElement;
+              };
+
+              const formData = {
+                recaptchaToken: captchaValue,
+                name: formElements.name.value,
+                instagram: formElements.instagram.value,
+                email: formElements.email.value,
+                equipmentDesired: selectedEquipment,
+                rentalStartDate: formElements.startDate.value,
+                rentalEndDate: formElements.endDate.value,
+                projectDescription: formElements.projectDescription.value,
+                formType: "rental", // Identify this as a rental request
+              };
+
+              try {
+                const response = await fetch("/api/contact", {
+                  method: "POST",
+                  headers: {
+                    "Content-Type": "application/json",
+                  },
+                  body: JSON.stringify(formData),
+                });
+
+                if (response.ok) {
+                  alert("Thank you! Your rental request has been sent.");
+                  form.reset();
+                  setSelectedEquipment([]);
+                  recaptchaRef.current?.reset();
+                } else {
+                  throw new Error("Failed to send request");
+                }
+              } catch {
+                alert("An error occurred. Please try again.");
+              }
+            }}
+          >
+            {/* Name */}
+            <TextField
+              name="name"
+              placeholder="NAME"
+              required
+              fullWidth
+              inputProps={{ "aria-label": "Name" }}
+              sx={FIELD_SX}
+            />
+
+            {/* Instagram */}
+            <TextField
+              name="instagram"
+              placeholder="INSTAGRAM"
+              required
+              fullWidth
+              inputProps={{ "aria-label": "Instagram" }}
+              sx={FIELD_SX}
+            />
+
+            {/* Email */}
+            <TextField
+              name="email"
+              type="email"
+              placeholder="EMAIL"
+              required
+              fullWidth
+              inputProps={{ "aria-label": "Email" }}
+              sx={FIELD_SX}
+            />
+
+            {/* Equipment Desired - Dropdown */}
+            <FormControl fullWidth sx={FIELD_SX}>
+              <InputLabel id="equipment-label">EQUIPMENT DESIRED</InputLabel>
+              <Select
+                labelId="equipment-label"
+                multiple
+                value={selectedEquipment}
+                onChange={handleEquipmentChange}
+                label="EQUIPMENT DESIRED"
+                required
+                inputProps={{ "aria-label": "Equipment Desired" }}
+                MenuProps={MENU_PROPS}
+              >
+                {rentalEquipment.map((item) => (
+                  <MenuItem key={item.name} value={item.name}>
+                    {item.name}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+
+            {/* Rental Timeframe - Start and End Date */}
+            <Box sx={{ display: "flex", gap: 2, flexDirection: { xs: "column", sm: "row" } }}>
+              <TextField
+                name="startDate"
+                type="datetime-local"
+                required
+                fullWidth
+                label="RENTAL START DATE"
+                InputLabelProps={{ shrink: true }}
+                inputProps={{ "aria-label": "Rental Start Date" }}
+                sx={FIELD_SX}
+              />
+              <TextField
+                name="endDate"
+                type="datetime-local"
+                required
+                fullWidth
+                label="RENTAL END DATE"
+                InputLabelProps={{ shrink: true }}
+                inputProps={{ "aria-label": "Rental End Date" }}
+                sx={FIELD_SX}
+              />
+            </Box>
+
+            {/* Project Description */}
+            <TextField
+              name="projectDescription"
+              placeholder="DESCRIPTION OF PROJECT"
+              required
+              fullWidth
+              multiline
+              minRows={4}
+              inputProps={{ "aria-label": "Project Description" }}
+              sx={FIELD_SX}
+            />
+
+            {/* ReCAPTCHA */}
+            <Box sx={{ display: "flex", justifyContent: { xs: "center", md: "flex-start" } }}>
+              <ReCAPTCHA
+                ref={recaptchaRef}
+                sitekey={process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY || ""}
+              />
+            </Box>
+
+            {/* Submit Button */}
+            <Button
+              type="submit"
+              disableElevation
+              sx={{ ...NB_BUTTON_SX, width: "100%", py: 1.75, fontSize: 14 }}
+            >
+              SUBMIT RENTAL REQUEST
+            </Button>
+          </Box>
         </Box>
-
-        {/* Submit Button */}
-        <Button
-          type="submit"
-          variant="contained"
-          sx={{
-            alignSelf: "center",
-            px: 4,
-            py: 1.5,
-            width: "80dvw",
-            maxWidth: 900,
-            fontWeight: 700,
-            bgcolor: "#16a34a",
-            "&:hover": { bgcolor: "#1d4ed8" },
-          }}
-        >
-          SUBMIT RENTAL REQUEST
-        </Button>
       </Box>
     </Box>
   );

--- a/app/rentals/page.tsx
+++ b/app/rentals/page.tsx
@@ -3,6 +3,12 @@ import { Box, Typography } from "@mui/material";
 import RentalGrid from "../components/RentalGrid";
 import RentalForm from "./RentalForm";
 import Footer from "../ui/Footer";
+import {
+  NB_COLORS,
+  NB_DISPLAY_SX,
+  NB_MONO_SX,
+  NB_RULE,
+} from "@/lib/theme";
 
 export const metadata: Metadata = {
   title: "Rentals | DripDome - Props & Set Piece Rentals NYC",
@@ -42,47 +48,61 @@ export const metadata: Metadata = {
 export default function RentalsPage() {
   return (
     <>
-      <Box sx={{ backgroundColor: "black" }}>
-        <Box sx={{ backgroundColor: "black" }}>
-          <Typography
-            variant="h1"
-            component="h1"
-            color="white"
+      <Box component="main" sx={{ bgcolor: NB_COLORS.paper, color: NB_COLORS.ink }}>
+        {/* Hero band */}
+        <Box component="section" sx={{ borderBottom: NB_RULE }}>
+          <Box sx={{ px: { xs: 3, md: 6 }, py: { xs: 5, md: 8 } }}>
+            <Typography sx={{ ...NB_MONO_SX, fontSize: 12, color: NB_COLORS.steel, mb: 2 }}>
+              INVENTORY · PROPS + SET PIECES · NYC
+            </Typography>
+            <Typography
+              variant="h1"
+              component="h1"
+              sx={{
+                ...NB_DISPLAY_SX,
+                fontSize: { xs: 56, sm: 96, lg: 140 },
+                color: NB_COLORS.ink,
+              }}
+            >
+              RENTALS
+            </Typography>
+          </Box>
+        </Box>
+
+        {/* Equipment index */}
+        <Box component="section" sx={{ borderBottom: NB_RULE }}>
+          <Box
             sx={{
-              fontSize: { xs: "55px", sm: "95px", lg: "150px" },
-              fontWeight: "bold",
-              paddingTop: { xs: 4, md: 8 },
-              paddingLeft: "10px",
-              paddingRight: "10px",
-              textAlign: "center",
+              display: "flex",
+              alignItems: "baseline",
+              justifyContent: "space-between",
+              px: { xs: 3, md: 6 },
+              py: { xs: 3, md: 4 },
+              borderBottom: NB_RULE,
+              flexWrap: "wrap",
+              gap: 1,
             }}
           >
-            Rentals
-          </Typography>
-
-          {/* Equipment Grid */}
-          <Box sx={{ backgroundColor: "black", py: 4, px: { xs: 0, md: 8 } }}>
             <Typography
               variant="h2"
               component="h2"
-              color="white"
               sx={{
-                fontSize: { xs: "30px", sm: "45px", lg: "50px" },
-                fontWeight: "bold",
-                marginBottom: { xs: "20px", md: "30px" },
-                textAlign: "center",
+                ...NB_DISPLAY_SX,
+                fontSize: { xs: 32, sm: 48, lg: 64 },
+                color: NB_COLORS.ink,
               }}
             >
-              Rental Periods are minimum 1 week.
+              EQUIPMENT INDEX
             </Typography>
-            <RentalGrid />
+            <Typography sx={{ ...NB_MONO_SX, fontSize: 12, color: NB_COLORS.steel }}>
+              RENTAL PERIODS ARE MINIMUM 1 WEEK.
+            </Typography>
           </Box>
-
-          {/* Rental Request Form */}
-          <Box sx={{ backgroundColor: "black", py: 4 }}>
-            <RentalForm />
-          </Box>
+          <RentalGrid />
         </Box>
+
+        {/* Rental Request Form */}
+        <RentalForm />
       </Box>
       <Footer />
     </>

--- a/app/services/ServicesContent.tsx
+++ b/app/services/ServicesContent.tsx
@@ -1,11 +1,17 @@
 "use client";
 
 import { useState } from "react";
-import { Box, Typography, Collapse, IconButton } from "@mui/material";
+import { Box, Typography, Collapse } from "@mui/material";
 import { motion } from "framer-motion";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import Contact from "../components/Contact";
-import { BRAND_GRADIENT_TEXT_SX } from "@/lib/theme";
+import {
+  NB_COLORS,
+  NB_DISPLAY_SX,
+  NB_MONO_SX,
+  NB_OUTLINE_TEXT_SX,
+  NB_RULE,
+} from "@/lib/theme";
 
 const services = [
   {
@@ -169,79 +175,67 @@ function ServiceCard({
     >
       <Box
         onClick={onToggle}
+        role="button"
+        aria-expanded={isExpanded}
         sx={{
           cursor: "pointer",
-          position: "relative",
-          p: { xs: 2.5, md: 3.5 },
-          borderRadius: 3,
-          bgcolor: "rgba(255,255,255,0.03)",
-          border: "1px solid",
-          borderColor: isExpanded
-            ? "rgba(229,199,103,0.5)"
-            : "rgba(255,255,255,0.1)",
-          transition: "all 0.3s ease",
+          px: { xs: 3, md: 6 },
+          py: { xs: 2.5, md: 3 },
+          borderBottom: NB_RULE,
+          color: NB_COLORS.ink,
+          bgcolor: isExpanded ? NB_COLORS.silverLight : NB_COLORS.paper,
           "&:hover": {
-            bgcolor: "rgba(255,255,255,0.06)",
-            borderColor: isExpanded
-              ? "rgba(229,199,103,0.7)"
-              : "rgba(255,255,255,0.2)",
-            transform: "translateY(-2px)",
+            bgcolor: NB_COLORS.ink,
+            color: NB_COLORS.paperOnInk,
+            "& .svc-muted": { color: NB_COLORS.mutedOnInk },
           },
         }}
       >
         <Box
           sx={{
-            display: "flex",
-            alignItems: "flex-start",
-            justifyContent: "space-between",
-            gap: 2,
+            display: "grid",
+            gridTemplateColumns: { xs: "auto 1fr auto", md: "100px 1fr auto" },
+            alignItems: "start",
+            gap: { xs: 2, md: 3 },
           }}
         >
-          <Box sx={{ flex: 1 }}>
-            <Box sx={{ display: "flex", alignItems: "center", gap: 2, mb: 1 }}>
-              <Typography
-                sx={{
-                  fontSize: { xs: "12px", md: "14px" },
-                  fontWeight: 700,
-                  color: "#E5C767",
-                  letterSpacing: "0.1em",
-                }}
-              >
-                {service.number}
-              </Typography>
-              <Typography
-                variant="h3"
-                sx={{
-                  fontSize: { xs: "18px", sm: "22px", md: "26px" },
-                  fontWeight: 700,
-                  color: "white",
-                  lineHeight: 1.2,
-                }}
-              >
-                {service.title}
-              </Typography>
-            </Box>
+          <Typography
+            className="svc-muted"
+            sx={{ ...NB_MONO_SX, fontSize: 12, color: NB_COLORS.steel, pt: 0.5 }}
+          >
+            SVC.{service.number}
+          </Typography>
+          <Box>
             <Typography
+              variant="h3"
               sx={{
-                fontSize: { xs: "14px", md: "16px" },
-                color: "rgba(255,255,255,0.7)",
+                ...NB_DISPLAY_SX,
+                fontSize: { xs: 18, sm: 22, md: 26 },
+                color: "inherit",
+                mb: 1,
+              }}
+            >
+              {service.title}
+            </Typography>
+            <Typography
+              className="svc-muted"
+              sx={{
+                fontSize: { xs: 14, md: 16 },
+                color: NB_COLORS.steel,
                 lineHeight: 1.6,
               }}
             >
               {service.description}
             </Typography>
           </Box>
-          <IconButton
-            size="small"
+          <ExpandMoreIcon
             sx={{
-              color: "rgba(255,255,255,0.5)",
+              fontSize: 24,
+              color: "inherit",
               transform: isExpanded ? "rotate(180deg)" : "rotate(0deg)",
               transition: "transform 0.3s ease",
-              "&:hover": { bgcolor: "rgba(255,255,255,0.1)" },
             }}
-          >
-            <ExpandMoreIcon />
-          </IconButton>
+          />
         </Box>
 
         <Collapse in={isExpanded} timeout={300}>
@@ -249,9 +243,17 @@ function ServiceCard({
             sx={{
               mt: 2.5,
               pt: 2.5,
-              borderTop: "1px solid rgba(255,255,255,0.1)",
+              ml: { md: "100px" },
+              pl: { md: 3 },
+              borderTop: "2px solid currentColor",
             }}
           >
+            <Typography
+              className="svc-muted"
+              sx={{ ...NB_MONO_SX, fontSize: 11, color: NB_COLORS.steel, mb: 1.5 }}
+            >
+              INCLUDES
+            </Typography>
             <Box
               component="ul"
               sx={{
@@ -267,12 +269,10 @@ function ServiceCard({
                   component="li"
                   key={idx}
                   sx={{
-                    color: "rgba(255,255,255,0.85)",
-                    fontSize: { xs: "13px", md: "15px" },
+                    color: "inherit",
+                    fontSize: { xs: 13, md: 15 },
                     lineHeight: 1.6,
-                    "&::marker": {
-                      color: "#E5C767",
-                    },
+                    "&::marker": { color: "inherit" },
                   }}
                 >
                   {detail}
@@ -294,197 +294,141 @@ export default function ServicesContent() {
   };
 
   return (
-    <Box sx={{ bgcolor: "black", overflow: "hidden", minHeight: "100vh" }}>
-      {/* Hero Section */}
-      <Box
-        sx={{
-          maxWidth: "1200px",
-          mx: "auto",
-          px: { xs: 2, md: 6 },
-          pt: { xs: 6, md: 10 },
-          pb: { xs: 4, md: 8 },
-        }}
-      >
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6 }}
-        >
-          <Typography
-            variant="h1"
-            sx={{
-              fontSize: { xs: "42px", sm: "64px", md: "80px", lg: "96px" },
-              fontWeight: 800,
-              color: "white",
-              textAlign: "center",
-              mb: { xs: 3, md: 4 },
-              letterSpacing: "-0.02em",
-            }}
+    <Box sx={{ bgcolor: NB_COLORS.paper, color: NB_COLORS.ink, minHeight: "100vh" }}>
+      {/* Hero band */}
+      <Box component="section" sx={{ bgcolor: NB_COLORS.paper, borderBottom: NB_RULE }}>
+        <Box sx={{ px: { xs: 3, md: 6 }, py: { xs: 5, md: 8 }, maxWidth: 1440, mx: "auto" }}>
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6 }}
           >
-            WHAT WE{" "}
-            <Box
-              component="span"
-              sx={{ display: "inline", ...BRAND_GRADIENT_TEXT_SX }}
-            >
-              DO
-            </Box>
-          </Typography>
-        </motion.div>
-
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.15, duration: 0.6 }}
-        >
-          <Typography
-            sx={{
-              fontSize: { xs: "16px", sm: "18px", md: "22px" },
-              color: "rgba(255,255,255,0.85)",
-              textAlign: "center",
-              maxWidth: "900px",
-              mx: "auto",
-              lineHeight: 1.7,
-              mb: { xs: 2, md: 3 },
-            }}
-          >
-            At{" "}
-            <Box component="span" sx={{ color: "#E5C767", fontWeight: 600 }}>
-              Drip Dome Productions
-            </Box>
-            , we bring ideas to life through design, fabrication, and
-            storytelling. Our studio blends creativity, technical skill, and
-            resourceful problem solving to create sets, environments, and brand
-            moments that stand out.
-          </Typography>
-        </motion.div>
-      </Box>
-
-      {/* Core Services Header */}
-      <Box sx={{ maxWidth: "1200px", mx: "auto", px: { xs: 2, md: 6 } }}>
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.3, duration: 0.6 }}
-        >
-          <Box
-            sx={{
-              display: "flex",
-              alignItems: "center",
-              gap: 2,
-              mb: { xs: 3, md: 4 },
-            }}
-          >
-            <Box
+            <Typography sx={{ ...NB_MONO_SX, fontSize: 12, color: NB_COLORS.steel, mb: 2 }}>
+              SERVICES INDEX · NYC + LA
+            </Typography>
+            <Typography
+              variant="h1"
               sx={{
-                height: "2px",
-                flex: 1,
-                background:
-                  "linear-gradient(90deg, transparent, rgba(229,199,103,0.5))",
+                ...NB_DISPLAY_SX,
+                fontSize: { xs: 42, sm: 64, md: 80, lg: 96 },
+                color: NB_COLORS.ink,
+                mb: { xs: 3, md: 4 },
               }}
-            />
+            >
+              WHAT WE{" "}
+              <Box component="span" sx={{ ...NB_OUTLINE_TEXT_SX }}>
+                DO
+              </Box>
+            </Typography>
+          </motion.div>
+
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.15, duration: 0.6 }}
+          >
             <Typography
               sx={{
-                fontSize: { xs: "12px", md: "14px" },
-                fontWeight: 700,
-                color: "#E5C767",
-                letterSpacing: "0.2em",
-                textTransform: "uppercase",
+                fontSize: { xs: 16, sm: 18, md: 20 },
+                color: NB_COLORS.ink,
+                maxWidth: 820,
+                lineHeight: 1.7,
               }}
             >
-              Our Core Services
+              At{" "}
+              <Box component="span" sx={{ fontWeight: 700 }}>
+                Drip Dome Productions
+              </Box>
+              , we bring ideas to life through design, fabrication, and
+              storytelling. Our studio blends creativity, technical skill, and
+              resourceful problem solving to create sets, environments, and brand
+              moments that stand out.
             </Typography>
-            <Box
-              sx={{
-                height: "2px",
-                flex: 1,
-                background:
-                  "linear-gradient(90deg, rgba(229,199,103,0.5), transparent)",
-              }}
-            />
-          </Box>
-        </motion.div>
-      </Box>
-
-      {/* Services Grid */}
-      <Box
-        sx={{
-          maxWidth: "1200px",
-          mx: "auto",
-          px: { xs: 2, md: 6 },
-          pb: { xs: 6, md: 10 },
-        }}
-      >
-        <Box
-          sx={{
-            display: "grid",
-            gridTemplateColumns: { xs: "1fr", lg: "1fr 1fr" },
-            gap: { xs: 2, md: 3 },
-          }}
-        >
-          {services.map((service, index) => (
-            <ServiceCard
-              key={service.number}
-              service={service}
-              index={index}
-              isExpanded={expandedIndex === index}
-              onToggle={() => handleToggle(index)}
-            />
-          ))}
+          </motion.div>
         </Box>
       </Box>
 
-      {/* CTA Section */}
+      {/* Services index */}
+      <Box component="section" sx={{ bgcolor: NB_COLORS.paper }}>
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "baseline",
+            justifyContent: "space-between",
+            px: { xs: 3, md: 6 },
+            py: { xs: 3, md: 4 },
+            borderBottom: NB_RULE,
+            flexWrap: "wrap",
+            gap: 1,
+          }}
+        >
+          <Typography
+            variant="h2"
+            sx={{
+              ...NB_DISPLAY_SX,
+              fontSize: { xs: 32, sm: 48, lg: 64 },
+              color: NB_COLORS.ink,
+            }}
+          >
+            OUR CORE SERVICES
+          </Typography>
+          <Typography sx={{ ...NB_MONO_SX, fontSize: 12, color: NB_COLORS.steel }}>
+            11 LINES · TAP TO EXPAND
+          </Typography>
+        </Box>
+
+        {services.map((service, index) => (
+          <ServiceCard
+            key={service.number}
+            service={service}
+            index={index}
+            isExpanded={expandedIndex === index}
+            onToggle={() => handleToggle(index)}
+          />
+        ))}
+      </Box>
+
+      {/* CTA band */}
       <Box
+        component="section"
         sx={{
-          maxWidth: "1200px",
-          mx: "auto",
-          px: { xs: 2, md: 6 },
-          pb: { xs: 6, md: 10 },
+          bgcolor: NB_COLORS.silver,
+          borderBottom: NB_RULE,
+          px: { xs: 3, md: 6 },
+          py: { xs: 4, md: 6 },
         }}
       >
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.5, duration: 0.6 }}
+          transition={{ delay: 0.2, duration: 0.6 }}
         >
-          <Box
+          <Typography
+            variant="h2"
             sx={{
-              p: { xs: 4, md: 6 },
-              borderRadius: 4,
-              background:
-                "linear-gradient(135deg, rgba(229,199,103,0.1) 0%, rgba(59,130,246,0.1) 100%)",
-              border: "1px solid rgba(255,255,255,0.1)",
-              textAlign: "center",
+              ...NB_DISPLAY_SX,
+              fontSize: { xs: 24, sm: 32, md: 40 },
+              color: NB_COLORS.onSilver,
+              mb: 2,
             }}
           >
-            <Typography
-              variant="h2"
-              sx={{
-                fontSize: { xs: "24px", sm: "32px", md: "40px" },
-                fontWeight: 700,
-                color: "white",
-                mb: 2,
-              }}
-            >
-              Ready to Build Something Amazing?
-            </Typography>
-            <Typography
-              sx={{
-                fontSize: { xs: "14px", md: "18px" },
-                color: "rgba(255,255,255,0.7)",
-                maxWidth: "600px",
-                mx: "auto",
-              }}
-            >
-              From the first spark of an idea to the final reveal, we handle
-              every detail. Let&apos;s create something unforgettable together.
-            </Typography>
-          </Box>
+            Ready to Build Something Amazing?
+          </Typography>
+          <Typography
+            sx={{
+              fontSize: { xs: 14, md: 18 },
+              color: NB_COLORS.onSilver,
+              maxWidth: 600,
+            }}
+          >
+            From the first spark of an idea to the final reveal, we handle
+            every detail. Let&apos;s create something unforgettable together.
+          </Typography>
         </motion.div>
       </Box>
 
       {/* Contact Section */}
-      <Box component="section" id="contact" sx={{ py: { xs: 6, md: 10 } }}>
+      <Box component="section" id="contact" sx={{ scrollMarginTop: { xs: 95, md: 120 } }}>
         <Contact />
       </Box>
     </Box>

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -32,6 +32,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "monthly" as const,
     },
     {
+      path: "/podcast-studios",
+      priority: 0.9,
+      changeFrequency: "monthly" as const,
+    },
+    {
       path: "/video-photo",
       priority: 0.7,
       changeFrequency: "monthly" as const,

--- a/app/ui/Footer.tsx
+++ b/app/ui/Footer.tsx
@@ -3,51 +3,164 @@
 import React from "react";
 import Link from "next/link";
 import InstagramIcon from "@mui/icons-material/Instagram";
-import { Box, Container, IconButton, Typography } from "@mui/material";
+import { Box, Typography } from "@mui/material";
+import {
+  NB_COLORS,
+  NB_DISPLAY_SX,
+  NB_MONO_SX,
+} from "@/lib/theme";
+
+const NAV = [
+  { name: "PODCAST STUDIOS", href: "/podcast-studios" },
+  { name: "ACTIVATIONS", href: "/brand-activations" },
+  { name: "ABOUT", href: "/about-us" },
+  { name: "BLOG", href: "/blog" },
+  // Legacy pages kept live but out of nav: /portfolio, /services
+  // Rentals page taken down from nav for now; route still live at /rentals
+  // { name: "RENTALS", href: "/rentals" },
+];
+
+const STEEL_RULE = `2px solid ${NB_COLORS.mutedOnInk}`;
 
 export default function Footer() {
   return (
-    <Box component="footer" sx={{ bgcolor: "black", py: 2 }}>
-      <Container maxWidth="lg" sx={{ px: { xs: 2, md: 4 } }}>
-        <Box
+    <Box
+      component="footer"
+      sx={{ bgcolor: NB_COLORS.ink, color: NB_COLORS.paperOnInk, borderTop: `2px solid ${NB_COLORS.ink}` }}
+    >
+      {/* Giant wordmark */}
+      <Box sx={{ px: { xs: 2, md: 4 }, pt: { xs: 4, md: 6 }, overflow: "hidden" }}>
+        <Typography
+          aria-hidden
           sx={{
-            display: "flex",
-            justifyContent: "space-between",
-            alignItems: "center",
-            gap: 2,
+            ...NB_DISPLAY_SX,
+            fontSize: { xs: "17vw", md: "11vw" },
+            lineHeight: 0.85,
+            color: NB_COLORS.paperOnInk,
+            whiteSpace: "nowrap",
+            userSelect: "none",
           }}
         >
-          <IconButton
+          DRIPDOME
+        </Typography>
+      </Box>
+
+      {/* Link columns */}
+      <Box
+        sx={{
+          borderTop: STEEL_RULE,
+          mt: { xs: 3, md: 4 },
+          display: "grid",
+          gridTemplateColumns: { xs: "1fr", md: "1fr 1fr 1fr" },
+        }}
+      >
+        <Box
+          sx={{
+            px: { xs: 3, md: 4 },
+            py: 3,
+            borderRight: { md: STEEL_RULE },
+            borderBottom: { xs: STEEL_RULE, md: "none" },
+          }}
+        >
+          <Typography sx={{ ...NB_MONO_SX, fontSize: 11, color: NB_COLORS.mutedOnInk, mb: 1.5 }}>
+            INDEX
+          </Typography>
+          <Box sx={{ display: "flex", flexWrap: "wrap", columnGap: 3, rowGap: 1 }}>
+            {NAV.map((link) => (
+              <Typography
+                key={link.href}
+                component={Link}
+                href={link.href}
+                sx={{
+                  ...NB_MONO_SX,
+                  fontSize: 13,
+                  fontWeight: 700,
+                  color: NB_COLORS.paperOnInk,
+                  textDecoration: "none",
+                  "&:hover": { color: NB_COLORS.mutedOnInk },
+                }}
+              >
+                {link.name}
+              </Typography>
+            ))}
+          </Box>
+        </Box>
+
+        <Box
+          sx={{
+            px: { xs: 3, md: 4 },
+            py: 3,
+            borderRight: { md: STEEL_RULE },
+            borderBottom: { xs: STEEL_RULE, md: "none" },
+          }}
+        >
+          <Typography sx={{ ...NB_MONO_SX, fontSize: 11, color: NB_COLORS.mutedOnInk, mb: 1.5 }}>
+            LOCATIONS
+          </Typography>
+          <Typography sx={{ ...NB_MONO_SX, fontSize: 13, fontWeight: 700 }}>
+            NEW YORK CITY
+          </Typography>
+          <Typography sx={{ ...NB_MONO_SX, fontSize: 13, fontWeight: 700 }}>
+            LOS ANGELES
+          </Typography>
+        </Box>
+
+        <Box sx={{ px: { xs: 3, md: 4 }, py: 3 }}>
+          <Typography sx={{ ...NB_MONO_SX, fontSize: 11, color: NB_COLORS.mutedOnInk, mb: 1.5 }}>
+            FOLLOW
+          </Typography>
+          <Box
             component="a"
             href="https://www.instagram.com/dripdome"
             target="_blank"
             rel="noopener noreferrer"
             aria-label="DripDome Instagram"
             sx={{
-              bgcolor: "rgba(0,0,0,0.6)",
-              borderRadius: 2,
-              p: 1,
-              color: "common.white",
-              "&:hover": { bgcolor: "rgba(0,0,0,0.75)", color: "#E5C767" },
-            }}
-          >
-            <InstagramIcon sx={{ width: 28, height: 28 }} />
-          </IconButton>
-
-          <Typography
-            component={Link}
-            href="/privacy"
-            sx={{
-              color: "grey.500",
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 1,
+              color: NB_COLORS.paperOnInk,
               textDecoration: "none",
-              fontSize: 14,
-              "&:hover": { color: "grey.300" },
+              "&:hover": { color: NB_COLORS.mutedOnInk },
             }}
           >
-            Privacy Policy
-          </Typography>
+            <InstagramIcon sx={{ fontSize: 20 }} />
+            <Typography sx={{ ...NB_MONO_SX, fontSize: 13, fontWeight: 700 }}>
+              @DRIPDOME
+            </Typography>
+          </Box>
         </Box>
-      </Container>
+      </Box>
+
+      {/* Fine print */}
+      <Box
+        sx={{
+          borderTop: STEEL_RULE,
+          px: { xs: 3, md: 4 },
+          py: 1.5,
+          display: "flex",
+          justifyContent: "space-between",
+          flexWrap: "wrap",
+          gap: 1,
+        }}
+      >
+        <Typography sx={{ ...NB_MONO_SX, fontSize: 10, color: NB_COLORS.mutedOnInk }}>
+          © {new Date().getFullYear()} DRIPDOME PRODUCTIONS · WOMEN OWNED · BUILT IN-HOUSE
+        </Typography>
+        <Typography
+          component={Link}
+          href="/privacy"
+          sx={{
+            ...NB_MONO_SX,
+            fontSize: 10,
+            color: NB_COLORS.mutedOnInk,
+            textDecoration: "none",
+            "&:hover": { color: NB_COLORS.paperOnInk },
+          }}
+        >
+          PRIVACY POLICY
+        </Typography>
+      </Box>
     </Box>
   );
 }

--- a/app/ui/Navbar.tsx
+++ b/app/ui/Navbar.tsx
@@ -4,195 +4,276 @@ import React, { useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { usePathname } from "next/navigation";
-import HomeTwoToneIcon from "@mui/icons-material/HomeTwoTone";
-import MenuIcon from "@mui/icons-material/Menu";
+import CloseIcon from "@mui/icons-material/Close";
+import ArrowOutwardIcon from "@mui/icons-material/ArrowOutward";
+import { AppBar, Box, Button, Drawer, IconButton, Toolbar, Typography } from "@mui/material";
 import {
-  AppBar,
-  Box,
-  Button,
-  Container,
-  Drawer,
-  IconButton,
-  List,
-  ListItem,
-  ListItemButton,
-  ListItemText,
-  Toolbar,
-} from "@mui/material";
+  FONT_DISPLAY,
+  NB_BUTTON_SX,
+  NB_COLORS,
+  NB_MONO_SX,
+  NB_RULE,
+} from "@/lib/theme";
+
+const links = [
+  { name: "PODCAST STUDIOS", href: "/podcast-studios" },
+  { name: "ACTIVATIONS", href: "/brand-activations" },
+  { name: "ABOUT", href: "/about-us" },
+  { name: "BLOG", href: "/blog" },
+  // Legacy pages kept live but out of nav: /portfolio, /services
+  // Rentals page taken down from nav for now; route still live at /rentals
+  // { name: "RENTALS", href: "/rentals" },
+];
 
 export default function Navbar() {
   const pathname = usePathname();
   const [isOpen, setIsOpen] = useState(false);
-  const isOverlay = pathname === "/brand-activations" || pathname === "/";
-
-  const links = [
-    { name: "ABOUT US", href: "/about-us" },
-    { name: "PORTFOLIO", href: "/portfolio" },
-    { name: "SERVICES", href: "/services" },
-    { name: "ACTIVATIONS", href: "/brand-activations" },
-    { name: "RENTALS", href: "/rentals" },
-    { name: "BLOG", href: "/blog" },
-  ];
-
-  const toggleMenu = () => setIsOpen(!isOpen);
 
   return (
     <>
       <AppBar
         component="nav"
-        position="fixed"
+        position="sticky"
         elevation={0}
         sx={{
-          bgcolor: isOverlay ? "rgba(0,0,0,0.25)" : "black",
-          backdropFilter: isOverlay ? "blur(10px)" : undefined,
-          WebkitBackdropFilter: isOverlay ? "blur(10px)" : undefined,
-          left: 0,
-          right: 0,
-          width: "100%",
-
-          mx: "auto",
-          color: "common.white",
-          height: { xs: 95, md: 120 },
-          justifyContent: "center",
-          zIndex: (theme) => theme.zIndex.drawer + 1,
-          px: { md: 5.5 },
+          bgcolor: NB_COLORS.paper,
+          color: NB_COLORS.ink,
+          borderBottom: NB_RULE,
         }}
       >
-        <Container
-          maxWidth={false}
-          sx={{ maxWidth: 2000, px: { xs: 2, md: 0 } }}
+        {/* Tier 1: spec-sheet microbar */}
+        <Box
+          sx={{
+            bgcolor: NB_COLORS.ink,
+            color: NB_COLORS.paperOnInk,
+            display: "flex",
+            justifyContent: "space-between",
+            px: { xs: 2, md: 4 },
+            py: 0.5,
+          }}
         >
-          <Toolbar disableGutters sx={{ minHeight: "unset" }}>
-            <IconButton
-              component={Link}
-              href="/"
-              aria-label="Home"
+          <Typography sx={{ ...NB_MONO_SX, fontSize: { xs: 10, md: 11 } }}>
+            SET DESIGN + FABRICATION STUDIO
+          </Typography>
+          <Typography sx={{ ...NB_MONO_SX, fontSize: { xs: 10, md: 11 } }}>
+            NYC / LA · NOW BOOKING
+          </Typography>
+        </Box>
+
+        {/* Tier 2: main nav */}
+        <Toolbar
+          disableGutters
+          sx={{
+            minHeight: { xs: 64, md: 76 },
+            px: { xs: 2, md: 4 },
+            gap: 2,
+          }}
+        >
+          <Box
+            component={Link}
+            href="/"
+            aria-label="DripDome home"
+            sx={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 1.5,
+              textDecoration: "none",
+              color: NB_COLORS.ink,
+              mr: "auto",
+            }}
+          >
+            <Image
+              alt="DripDome logo"
+              src="/assets/dd_logo_200.png"
+              width={48}
+              height={48}
+              priority
+            />
+            <Typography
               sx={{
-                display: { md: "none" },
-                ml: 0.5,
-                borderRadius: 2,
-                color: "common.white",
-                p: 1,
-                "&:hover": { bgcolor: "rgba(0,0,0,0.75)" },
+                fontFamily: FONT_DISPLAY,
+                fontSize: { xs: 18, md: 22 },
+                letterSpacing: "0.02em",
+                display: { xs: "none", sm: "block" },
               }}
             >
-              <HomeTwoToneIcon sx={{ width: 28, height: 28 }} />
-            </IconButton>
+              DRIPDOME
+            </Typography>
+          </Box>
 
-            <Box
-              sx={{
-                flexGrow: 1,
-                display: "flex",
-                justifyContent: { xs: "center", md: "flex-start" },
-                alignItems: "center",
-              }}
-            >
-              <Box
-                component={Link}
-                href="/"
-                aria-label="DripDome home"
-                sx={{ display: "inline-flex", ml: { md: 2 } }}
-              >
-                <Image
-                  alt="DripDome - Set Design & Production Design Studio"
-                  src="/assets/dd_logo_200.png"
-                  width={100}
-                  height={100}
-                  priority
-                />
-              </Box>
-            </Box>
+          <Box sx={{ display: { xs: "none", lg: "flex" } }}>
+            {links.map((link) => {
+              const isActive = pathname === link.href;
+              return (
+                <Button
+                  key={link.name}
+                  component={Link}
+                  href={link.href}
+                  disableRipple
+                  sx={{
+                    ...NB_MONO_SX,
+                    fontSize: 13,
+                    fontWeight: 700,
+                    borderRadius: 0,
+                    px: 1.75,
+                    py: 1,
+                    color: isActive ? NB_COLORS.paperOnInk : NB_COLORS.ink,
+                    bgcolor: isActive ? NB_COLORS.ink : "transparent",
+                    "&:hover": {
+                      bgcolor: NB_COLORS.ink,
+                      color: NB_COLORS.paperOnInk,
+                    },
+                  }}
+                >
+                  {link.name}
+                </Button>
+              );
+            })}
+          </Box>
 
-            <IconButton
-              aria-label="Open navigation menu"
-              onClick={toggleMenu}
-              sx={{ display: { md: "none" }, mr: 1.5, color: "common.white" }}
-            >
-              <MenuIcon sx={{ width: 32, height: 32 }} />
-            </IconButton>
+          <Button
+            component={Link}
+            href="/#contact"
+            disableElevation
+            sx={{
+              ...NB_BUTTON_SX,
+              display: { xs: "none", md: "inline-flex" },
+              px: 2.5,
+              py: 1,
+              fontSize: 12,
+            }}
+          >
+            START A PROJECT
+          </Button>
 
-            <Box sx={{ display: { xs: "none", md: "flex" }, gap: 1 }}>
-              {links.map((link) => {
-                const isActive = pathname === link.href;
-                return (
-                  <Button
-                    key={link.name}
-                    component={Link}
-                    href={link.href}
-                    sx={{
-                      color: "common.white",
-                      fontSize: 18,
-                      fontWeight: 600,
-                      borderRadius: 0,
-                      borderBottom: isActive
-                        ? "2px solid #E5C767"
-                        : "2px solid transparent",
-                      "&:hover": { color: "#E5C767", bgcolor: "transparent" },
-                    }}
-                  >
-                    {link.name}
-                  </Button>
-                );
-              })}
-            </Box>
-          </Toolbar>
-        </Container>
+          <Button
+            aria-label="Open navigation menu"
+            onClick={() => setIsOpen(true)}
+            disableRipple
+            sx={{
+              display: { xs: "inline-flex", lg: "none" },
+              ...NB_MONO_SX,
+              fontSize: 13,
+              fontWeight: 700,
+              color: NB_COLORS.ink,
+              border: NB_RULE,
+              borderRadius: 0,
+              px: 2,
+              py: 0.75,
+              "&:hover": {
+                bgcolor: NB_COLORS.ink,
+                color: NB_COLORS.paperOnInk,
+              },
+            }}
+          >
+            MENU
+          </Button>
+        </Toolbar>
       </AppBar>
 
+      {/* Full-screen takeover menu */}
       <Drawer
         anchor="top"
         open={isOpen}
         onClose={() => setIsOpen(false)}
         PaperProps={{
           sx: {
-            bgcolor: "black",
-            color: "common.white",
-            height: "100vh",
+            bgcolor: NB_COLORS.paper,
+            color: NB_COLORS.ink,
+            height: "100dvh",
           },
         }}
       >
         <Box
-          role="presentation"
           sx={{
-            width: "100%",
-            height: "100%",
             display: "flex",
+            justifyContent: "space-between",
             alignItems: "center",
-            justifyContent: "center",
             px: 2,
+            py: 1.5,
+            borderBottom: NB_RULE,
           }}
         >
-          <List sx={{ width: "100%", maxWidth: 420 }}>
-            {links.map((link) => (
-              <ListItem key={link.name} disablePadding sx={{ my: 0.75 }}>
-                <ListItemButton
-                  component={Link}
-                  href={link.href}
-                  onClick={() => setIsOpen(false)}
-                  sx={{
-                    bgcolor: "rgba(0,0,0,0.7)",
-                    borderRadius: 2,
-                    "&:hover": { color: "#E5C767" },
-                  }}
-                >
-                  <ListItemText
-                    primary={link.name}
-                    primaryTypographyProps={{
-                      align: "center",
-                      fontSize: 22,
-                      fontWeight: 600,
-                    }}
-                  />
-                </ListItemButton>
-              </ListItem>
-            ))}
-          </List>
+          <Typography sx={{ ...NB_MONO_SX, fontSize: 11 }}>
+            DRIPDOME · INDEX
+          </Typography>
+          <IconButton
+            aria-label="Close navigation menu"
+            onClick={() => setIsOpen(false)}
+            sx={{
+              color: NB_COLORS.ink,
+              border: NB_RULE,
+              borderRadius: 0,
+              p: 0.75,
+            }}
+          >
+            <CloseIcon />
+          </IconButton>
+        </Box>
+
+        <Box component="nav" sx={{ flex: 1, overflowY: "auto" }}>
+          {links.map((link, i) => (
+            <Box
+              key={link.name}
+              component={Link}
+              href={link.href}
+              onClick={() => setIsOpen(false)}
+              sx={{
+                display: "flex",
+                alignItems: "baseline",
+                gap: 2,
+                px: 2.5,
+                py: 2,
+                borderBottom: NB_RULE,
+                textDecoration: "none",
+                color: NB_COLORS.ink,
+                "&:hover": {
+                  bgcolor: NB_COLORS.ink,
+                  color: NB_COLORS.paperOnInk,
+                },
+              }}
+            >
+              <Typography sx={{ ...NB_MONO_SX, fontSize: 12, color: NB_COLORS.steel }}>
+                {String(i + 1).padStart(2, "0")}
+              </Typography>
+              <Typography
+                sx={{
+                  fontFamily: FONT_DISPLAY,
+                  fontSize: { xs: 34, sm: 44 },
+                  lineHeight: 1,
+                  color: "inherit",
+                }}
+              >
+                {link.name}
+              </Typography>
+            </Box>
+          ))}
+
+          <Box
+            component={Link}
+            href="/#contact"
+            onClick={() => setIsOpen(false)}
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              px: 2.5,
+              py: 2.5,
+              bgcolor: NB_COLORS.ink,
+              color: NB_COLORS.paperOnInk,
+              textDecoration: "none",
+              "&:hover": { bgcolor: NB_COLORS.steel },
+            }}
+          >
+            <Typography
+              sx={{ fontFamily: FONT_DISPLAY, fontSize: { xs: 34, sm: 44 }, lineHeight: 1 }}
+            >
+              START A PROJECT
+            </Typography>
+            <ArrowOutwardIcon sx={{ fontSize: 36 }} />
+          </Box>
         </Box>
       </Drawer>
-
-      {/* Spacer so content isn't hidden behind the fixed AppBar.
-          Skipped on overlay routes where the hero intentionally sits under the navbar. */}
-      {!isOverlay && <Box sx={{ height: { xs: 95, md: 120 } }} />}
     </>
   );
 }

--- a/app/video-photo/page.tsx
+++ b/app/video-photo/page.tsx
@@ -1,12 +1,12 @@
 import { Metadata } from "next";
+import Image from "next/image";
+import { Box, Typography } from "@mui/material";
 import {
-  Box,
-  Card,
-  CardContent,
-  CardMedia,
-  Container,
-  Typography,
-} from "@mui/material";
+  NB_COLORS,
+  NB_DISPLAY_SX,
+  NB_MONO_SX,
+  NB_RULE,
+} from "@/lib/theme";
 
 export const metadata: Metadata = {
   title: "Video & Photo | DripDome - Set Design for Film & Photography NYC",
@@ -43,43 +43,95 @@ export const metadata: Metadata = {
   },
 };
 
+const S3 = "https://dripdome-site.s3.us-east-2.amazonaws.com";
+
 export default function VideoPhotoPage() {
-  // Placeholder data for the gallery
   const galleryImages = [
-    { id: 1, src: "/images/work1.jpg", alt: "Project 1", caption: "Project 1" },
-    { id: 2, src: "/images/work2.jpg", alt: "Project 2", caption: "Project 2" },
-    { id: 3, src: "/images/work3.jpg", alt: "Project 3", caption: "Project 3" },
-    { id: 4, src: "/images/work4.jpg", alt: "Project 4", caption: "Project 4" },
-    { id: 5, src: "/images/work5.jpg", alt: "Project 5", caption: "Project 5" },
+    {
+      id: 1,
+      src: `${S3}/NLL/IMG_1.JPG`,
+      alt: "NotLoveline podcast set designed and fabricated by DripDome",
+      caption: "NOTLOVELINE PODCAST SET",
+    },
+    {
+      id: 2,
+      src: `${S3}/goog-photos/ejae.png`,
+      alt: "Google Photos video recap campaign set design featuring EJAE",
+      caption: "GOOGLE PHOTOS CAMPAIGN",
+    },
+    {
+      id: 3,
+      src: `${S3}/jennifersbody/jb4.png`,
+      alt: "Jennifers Body pool scene recreation built by DripDome",
+      caption: "JENNIFERS BODY POOL SET",
+    },
+    {
+      id: 4,
+      src: `${S3}/southside/ss1.png`,
+      alt: "The Original Southside ad campaign styling and props",
+      caption: "ORIGINAL SOUTHSIDE CAMPAIGN",
+    },
+    {
+      id: 5,
+      src: `${S3}/lesgc/view.jpg`,
+      alt: "Lower East Side Girls Club charity event photo installation",
+      caption: "LESGC PHOTO MOMENT",
+    },
+    {
+      id: 6,
+      src: `${S3}/SETDESIGN/sd_1.JPG`,
+      alt: "Custom set design build for an editorial photoshoot",
+      caption: "EDITORIAL SET BUILD",
+    },
   ];
 
   return (
-    <Box
-      component="section"
-      id="work-gallery"
-      sx={{ py: 16, bgcolor: "grey.100" }}
-    >
-      <Container maxWidth="lg" sx={{ px: { xs: 2, md: 4 } }}>
-        <Typography
-          variant="h2"
-          component="h2"
+    <Box component="main" sx={{ bgcolor: NB_COLORS.paper, color: NB_COLORS.ink }}>
+      <Box
+        component="section"
+        id="work-gallery"
+        sx={{ bgcolor: NB_COLORS.paper, borderBottom: NB_RULE }}
+      >
+        {/* Section header */}
+        <Box
           sx={{
-            textAlign: "center",
-            color: "grey.900",
-            mb: 4,
-            fontWeight: 800,
+            display: "flex",
+            alignItems: "baseline",
+            justifyContent: "space-between",
+            px: { xs: 3, md: 6 },
+            py: { xs: 3, md: 4 },
+            borderBottom: NB_RULE,
+            flexWrap: "wrap",
+            gap: 1,
           }}
         >
-          Our Work
-        </Typography>
-        <Typography
-          variant="body1"
-          component="p"
-          sx={{ textAlign: "center", color: "grey.700", mb: 8 }}
-        >
-          Explore some of the amazing projects we&apos;ve worked on.
-        </Typography>
+          <Typography
+            variant="h2"
+            component="h2"
+            sx={{
+              ...NB_DISPLAY_SX,
+              fontSize: { xs: 32, sm: 48, lg: 64 },
+              color: NB_COLORS.ink,
+            }}
+          >
+            OUR WORK
+          </Typography>
+          <Typography sx={{ ...NB_MONO_SX, fontSize: 12, color: NB_COLORS.steel }}>
+            VIDEO + PHOTO · CONTACT SHEET
+          </Typography>
+        </Box>
 
+        {/* Intro band */}
+        <Box sx={{ px: { xs: 3, md: 6 }, py: { xs: 2, md: 2.5 }, borderBottom: NB_RULE }}>
+          <Typography
+            component="p"
+            sx={{ fontSize: { xs: 14, md: 16 }, color: NB_COLORS.steel }}
+          >
+            Explore some of the amazing projects we&apos;ve worked on.
+          </Typography>
+        </Box>
+
+        {/* Framed plates */}
         <Box
           sx={{
             display: "grid",
@@ -87,54 +139,53 @@ export default function VideoPhotoPage() {
               xs: "1fr",
               sm: "repeat(2, 1fr)",
               md: "repeat(3, 1fr)",
-              lg: "repeat(4, 1fr)",
             },
-            gap: 3,
           }}
         >
-          {galleryImages.map((image) => (
-            <Card
+          {galleryImages.map((image, i) => (
+            <Box
               key={image.id}
               sx={{
-                position: "relative",
-                overflow: "hidden",
-                borderRadius: 2,
-                boxShadow: 3,
-                "&:hover .MuiCardMedia-root": { transform: "scale(1.08)" },
-                "&:hover .MuiCardContent-root": { opacity: 1 },
+                bgcolor: NB_COLORS.well,
+                borderRight: {
+                  sm: i % 2 === 0 ? NB_RULE : "none",
+                  md: (i + 1) % 3 !== 0 ? NB_RULE : "none",
+                },
+                borderBottom: {
+                  xs: i < galleryImages.length - 1 ? NB_RULE : "none",
+                  sm: i < galleryImages.length - 2 ? NB_RULE : "none",
+                  md: i < galleryImages.length - 3 ? NB_RULE : "none",
+                },
               }}
             >
-              <CardMedia
-                component="img"
-                image={image.src}
-                alt={image.alt}
-                height={192}
-                sx={{
-                  height: 192,
-                  transition: "transform 300ms ease",
-                  objectFit: "cover",
-                }}
-              />
-              <CardContent
-                sx={{
-                  position: "absolute",
-                  bottom: 0,
-                  left: 0,
-                  right: 0,
-                  bgcolor: "rgba(0,0,0,0.5)",
-                  color: "common.white",
-                  textAlign: "center",
-                  py: 1,
-                  opacity: 0,
-                  transition: "opacity 300ms ease",
-                }}
-              >
-                <Typography variant="body2">{image.caption}</Typography>
-              </CardContent>
-            </Card>
+              <Box sx={{ p: { xs: 2, md: 3 } }}>
+                <Box
+                  sx={{
+                    position: "relative",
+                    aspectRatio: "4 / 3",
+                    border: NB_RULE,
+                  }}
+                >
+                  <Image
+                    src={image.src}
+                    alt={image.alt}
+                    fill
+                    sizes="(max-width: 600px) 100vw, (max-width: 900px) 50vw, 33vw"
+                    style={{ objectFit: "cover" }}
+                  />
+                </Box>
+              </Box>
+              <Box sx={{ px: { xs: 2, md: 3 }, pb: { xs: 2, md: 3 } }}>
+                <Typography
+                  sx={{ ...NB_MONO_SX, fontSize: 12, color: NB_COLORS.steel }}
+                >
+                  FIG. {String(i + 1).padStart(2, "0")} · {image.caption}
+                </Typography>
+              </Box>
+            </Box>
           ))}
         </Box>
-      </Container>
+      </Box>
     </Box>
   );
 }

--- a/lib/projects.ts
+++ b/lib/projects.ts
@@ -1,0 +1,166 @@
+/**
+ * Central project registry for the work archive and vertical pages.
+ * The home page renders every entry; vertical landing pages filter by
+ * `vertical`. Add new builds here and they flow everywhere.
+ */
+
+const S3 = "https://dripdome-site.s3.us-east-2.amazonaws.com";
+
+export type VerticalKey =
+  | "podcast"
+  | "activation"
+  | "setDesign"
+  | "musicVideo";
+
+export interface Vertical {
+  key: VerticalKey;
+  label: string;
+  /** Landing page. Legacy verticals have none: shown in the archive only. */
+  href?: string;
+  /** Sunset services: still taken for the right project, not promoted. */
+  legacy?: boolean;
+}
+
+export const VERTICALS: Record<VerticalKey, Vertical> = {
+  podcast: {
+    key: "podcast",
+    label: "PODCAST STUDIOS",
+    href: "/podcast-studios",
+  },
+  activation: {
+    key: "activation",
+    label: "BRAND ACTIVATIONS",
+    href: "/brand-activations",
+  },
+  setDesign: { key: "setDesign", label: "SET DESIGN", legacy: true },
+  musicVideo: { key: "musicVideo", label: "MUSIC VIDEOS", legacy: true },
+};
+
+export interface ProjectStat {
+  value: string;
+  label: string;
+}
+
+export interface Project {
+  slug: string;
+  jobNo: string;
+  client: string;
+  title: string;
+  vertical: VerticalKey;
+  scope: string;
+  blurb: string;
+  images: string[];
+  stats: ProjectStat[];
+  /** Featured projects get a full job file on the home archive. */
+  featured?: boolean;
+}
+
+export const PROJECTS: Project[] = [
+  {
+    slug: "notloveline",
+    jobNo: "01",
+    client: "TRISHA PAYTAS x TANA MONGEAU",
+    title: "THE SET OF NOTLOVELINE",
+    vertical: "podcast",
+    scope: "STUDIO DESIGN · FABRICATION · CUSTOM WIRING",
+    blurb: `Designed and fabricated the NotLoveline podcast studio for Trisha Paytas and Tana Mongeau in four days. A vaporwave inspired environment anchored by a hand wired LED neon heart wall with alternating color sequences. The set has since carried 65+ episodes and crossed 20 million YouTube views with 230K+ subscribers.`,
+    images: [
+      `${S3}/NLL/IMG_1.JPG`,
+      `${S3}/NLL/IMG_2.JPG`,
+      `${S3}/NLL/IMG_3.JPG`,
+      `${S3}/NLL/IMG_4.jpeg`,
+      `${S3}/NLL/IMG_5.jpeg`,
+    ],
+    stats: [
+      { value: "20M+", label: "YOUTUBE VIEWS" },
+      { value: "230K+", label: "SUBSCRIBERS" },
+      { value: "65+", label: "EPISODES SHOT" },
+      { value: "4 DAYS", label: "BUILD TIMELINE" },
+    ],
+    featured: true,
+  },
+  {
+    slug: "google-photos",
+    jobNo: "02",
+    client: "GOOGLE PHOTOS",
+    title: "VIDEO RECAP CAMPAIGN",
+    vertical: "activation",
+    scope: "PRODUCTION DESIGN · SET DRESSING · PROP SOURCING",
+    blurb: `Led production design for Google Photos' video recap campaign featuring K-pop star EJAE. Full scope: set design, prop and furniture sourcing, and complete set dressing across multiple color stories. Every visual element curated to support a clean, lifestyle driven aesthetic aligned with the brand.`,
+    images: [
+      `${S3}/goog-photos/ejae.png`,
+      `${S3}/goog-photos/purple.jpg`,
+      `${S3}/goog-photos/red.jpg`,
+      `${S3}/goog-photos/laydown.jpg`,
+    ],
+    stats: [
+      { value: "214K+", label: "IG ENGAGEMENTS" },
+      { value: "208K+", label: "LIKES" },
+      { value: "2.5K+", label: "REPOSTS" },
+      { value: "1K+", label: "COMMENTS" },
+    ],
+    featured: true,
+  },
+  {
+    slug: "lesgc-alice",
+    jobNo: "03",
+    client: "LOWER EAST SIDE GIRLS CLUB",
+    title: "ALICE IN WONDERLAND GALA",
+    vertical: "activation",
+    scope: "CONCEPT · FABRICATION · TWO-HOUR VENUE INSTALL",
+    blurb: `Built a 10 by 8 foot Alice in Wonderland photo moment featuring custom vinyl wrapped playing cards with the organization's initials and a lush garden wall backdrop. Fabricated off site and installed in under two hours despite strict venue constraints. Organizers cited it as the highlight of the evening.`,
+    images: [
+      `${S3}/lesgc/view.jpg`,
+      `${S3}/lesgc/twogirls.jpg`,
+      `${S3}/lesgc/frame.jpg`,
+      `${S3}/lesgc/render.jpg`,
+      `${S3}/lesgc/mattdiana.jpg`,
+    ],
+    stats: [
+      { value: "200+", label: "GUESTS" },
+      { value: "100+", label: "UGC STORIES" },
+      { value: "< 2 HR", label: "VENUE INSTALL" },
+      { value: "10 × 8 FT", label: "CUSTOM BUILD" },
+    ],
+    featured: true,
+  },
+  {
+    slug: "original-southside",
+    jobNo: "04",
+    client: "THE ORIGINAL SOUTHSIDE",
+    title: "PRODUCT LAUNCH CAMPAIGN",
+    vertical: "activation",
+    scope: "PROP SOURCING · STYLING · CUSTOM VINYL",
+    blurb: `Collaborated with The Original Southside on their launch ad campaign. Scope included prop sourcing, styling, and custom vinyl wraps that reinforced a modern twist on the classic 1920s Southside cocktail. The campaign and product were later named among Forbes' Best Canned Cocktails.`,
+    images: [
+      `${S3}/southside/ss1.png`,
+      `${S3}/southside/ss2.png`,
+      `${S3}/southside/ss3.png`,
+      `${S3}/southside/ss4.png`,
+    ],
+    stats: [
+      { value: "FORBES", label: "BEST CANNED COCKTAIL" },
+      { value: "LAUNCH", label: "CAMPAIGN SCOPE" },
+      { value: "CUSTOM", label: "VINYL FABRICATION" },
+    ],
+  },
+  {
+    slug: "sunnyd",
+    jobNo: "05",
+    client: "WHETHAN x EMEI",
+    title: "'SUNNYD' MUSIC VIDEO",
+    vertical: "musicVideo",
+    scope: "WORLD BUILDING · PROPS · BRANDED VINYL",
+    blurb: `Transformed a vacant office building into the world of the 'SUNNYD' music video for Whethan and Emei. We worked with the bones of the space, trucking in custom props, branded vinyl, and layered dressing. Empty corridors, lobbies, and offices became distinct performance and narrative beats inside the track's saturated Sunny D palette.`,
+    images: [`${S3}/sunnyd/still.jpg`],
+    stats: [
+      { value: "444K+", label: "YOUTUBE VIEWS" },
+      { value: "OFFICIAL", label: "MUSIC VIDEO" },
+    ],
+  },
+];
+
+export const featuredProjects = () => PROJECTS.filter((p) => p.featured);
+
+export const projectsByVertical = (key: VerticalKey) =>
+  PROJECTS.filter((p) => p.vertical === key);

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -1,3 +1,149 @@
+/**
+ * ============================================================
+ * NEOBRUTALIST DESIGN SYSTEM — single source of truth
+ * ============================================================
+ * To retheme the site, edit NB_COLORS (and NB_BORDER_WIDTH /
+ * NB_SHADOW_OFFSET if you want chunkier or thinner hardware).
+ * Nothing below hardcodes a color; every component imports
+ * from here.
+ */
+
+export const NB_COLORS = {
+  /** Page background */
+  paper: "#131313",
+  /** Raised surfaces: cards, form fields, image plates */
+  surface: "#1D1D1B",
+  /** Text, borders, inverted bands, primary buttons */
+  ink: "#F2F2EF",
+  /** Text sitting on ink bands (always the opposite pole of `ink`) */
+  paperOnInk: "#131313",
+  /** Accent blocks, highlighted cells, hover fills */
+  silver: "#C7CAD0",
+  /** Subtle fills, alternating cells: one step off `paper` */
+  silverLight: "#26282A",
+  /** Secondary text, captions, mono metadata (must read on `paper`) */
+  steel: "#9CA1A7",
+  /** Text on `silver` fills (always dark, silver stays light in any theme) */
+  onSilver: "#131313",
+  /** Muted text and rules on `ink` bands (low-contrast against `ink`) */
+  mutedOnInk: "#5F6367",
+  /** Media well behind white logo assets. Keep dark in ANY theme,
+   *  the press/brand logo PNGs are white artwork. */
+  well: "#0B0B0C",
+} as const;
+
+export const NB_BORDER_WIDTH = 2;
+export const NB_SHADOW_OFFSET = 6;
+
+/** 2px solid ink rule, the default border everywhere */
+export const NB_RULE = `${NB_BORDER_WIDTH}px solid ${NB_COLORS.ink}`;
+
+/** Hard zero-blur offset shadow */
+export const nbShadow = (
+  px: number = NB_SHADOW_OFFSET,
+  color: string = NB_COLORS.ink,
+) => `${px}px ${px}px 0 ${color}`;
+
+/* ---------- Typography ---------- */
+/** CSS variables are registered in app/layout.tsx via next/font */
+export const FONT_DISPLAY =
+  "var(--font-display), Impact, 'Arial Black', sans-serif";
+export const FONT_MONO =
+  "var(--font-mono), 'SFMono-Regular', 'Courier New', monospace";
+
+/** Big blocky headline type */
+export const NB_DISPLAY_SX = {
+  fontFamily: FONT_DISPLAY,
+  textTransform: "uppercase",
+  lineHeight: 0.95,
+  letterSpacing: "0.01em",
+  fontWeight: 400,
+} as const;
+
+/** Spec-sheet metadata type: labels, captions, indexes */
+export const NB_MONO_SX = {
+  fontFamily: FONT_MONO,
+  textTransform: "uppercase",
+  letterSpacing: "0.08em",
+} as const;
+
+/** Outlined (stroke-only) display text on paper */
+export const NB_OUTLINE_TEXT_SX = {
+  ...NB_DISPLAY_SX,
+  color: "transparent",
+  WebkitTextStroke: `${NB_BORDER_WIDTH}px ${NB_COLORS.ink}`,
+} as const;
+
+/* ---------- Interactive hardware ---------- */
+
+const NB_PRESS_MECHANIC = {
+  transition: "transform 120ms ease, box-shadow 120ms ease",
+  "&:hover": {
+    transform: "translate(2px, 2px)",
+    boxShadow: nbShadow(NB_SHADOW_OFFSET - 3),
+  },
+  "&:active": {
+    transform: `translate(${NB_SHADOW_OFFSET}px, ${NB_SHADOW_OFFSET}px)`,
+    boxShadow: nbShadow(0),
+  },
+} as const;
+
+/** Primary button: ink block, paper text, press-down mechanic */
+export const NB_BUTTON_SX = {
+  fontFamily: FONT_MONO,
+  fontWeight: 700,
+  letterSpacing: "0.1em",
+  borderRadius: 0,
+  border: NB_RULE,
+  bgcolor: NB_COLORS.ink,
+  color: NB_COLORS.paperOnInk,
+  boxShadow: nbShadow(),
+  "&:hover": {
+    ...NB_PRESS_MECHANIC["&:hover"],
+    bgcolor: NB_COLORS.ink,
+  },
+  "&:active": NB_PRESS_MECHANIC["&:active"],
+  transition: NB_PRESS_MECHANIC.transition,
+} as const;
+
+/** Secondary button: surface block, ink text */
+export const NB_BUTTON_OUTLINE_SX = {
+  fontFamily: FONT_MONO,
+  fontWeight: 700,
+  letterSpacing: "0.1em",
+  borderRadius: 0,
+  border: NB_RULE,
+  bgcolor: NB_COLORS.surface,
+  color: NB_COLORS.ink,
+  boxShadow: nbShadow(),
+  "&:hover": {
+    ...NB_PRESS_MECHANIC["&:hover"],
+    bgcolor: NB_COLORS.silverLight,
+  },
+  "&:active": NB_PRESS_MECHANIC["&:active"],
+  transition: NB_PRESS_MECHANIC.transition,
+} as const;
+
+/** Square bordered tag / chip */
+export const NB_TAG_SX = {
+  ...NB_MONO_SX,
+  display: "inline-flex",
+  alignItems: "center",
+  px: 1.5,
+  py: 0.5,
+  border: NB_RULE,
+  bgcolor: NB_COLORS.surface,
+  color: NB_COLORS.ink,
+  fontWeight: 500,
+} as const;
+
+/* ============================================================
+ * LEGACY champagne-gold tokens.
+ * Still imported by interior routes (blog, portfolio, services,
+ * brand-activations) that have not been converted yet. Do not
+ * use in new work.
+ * ============================================================ */
+
 export const BRAND_ACCENT = "#E5C767";
 export const BRAND_ACCENT_DEEP = "#C9A227";
 


### PR DESCRIPTION
Replaces the champagne-gold theme with a centralized neobrutalist design system (dark white/black/silver `NB_COLORS` palette in `lib/theme.ts`, 2px ink rules, hard offset shadows, Archivo Black + IBM Plex Mono) and reworks core structures: two-tier sticky navbar, editorial hero with ticker, scroll-snap job-file filmstrips replacing all Swiper carousels, and a colophon footer.

Reorganizes the site around two specialty verticals with a new SEO-complete `/podcast-studios` landing page alongside `/brand-activations`, routed from a "What do you need built?" band, while the home page becomes the master work archive fed by a new central project registry (`lib/projects.ts`).

Set design and music videos are demoted to legacy archive entries, and rentals/portfolio/services stay live but leave the nav.

Every remaining route (brand-activations, blog + posts, portfolio, services, about-us, rentals, video-photo, privacy) is converted to the new system with form logic, reCAPTCHA, Google Ads conversion tracking, and structured data preserved.

Verified with tsc, production build (20 routes), lint, and full-page screenshots of every route.